### PR TITLE
fix #52

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@
 * Steven Libby
 * Paul Miner
 * Lorenzo Gallucci
+* Fernando Marino`
 * AMD Corporation
 
 # Details

--- a/src/main/java/com/aparapi/internal/opencl/OpenCLLoader.java
+++ b/src/main/java/com/aparapi/internal/opencl/OpenCLLoader.java
@@ -44,7 +44,7 @@ public class OpenCLLoader extends OpenCLJNI{
                logger.info("Aparapi JNI loaded successfully.");
                openCLAvailable = true;
             }
-            catch (final IOException e) {
+            catch (final IOException | UnsatisfiedLinkError e) {
                logger.log(Level.SEVERE, "Check your environment. Failed to load codegen native library "
                      + " or possibly failed to locate opencl native library (opencl.dll/opencl.so)."
                      + " Ensure that OpenCL is in your PATH (windows) or in LD_LIBRARY_PATH (linux).");


### PR DESCRIPTION
Catch unsatisfied link error along IOException in case it fails to detect openCL 