### PR TITLE
Update: Add complete suppport for OpenCL 1.2 atomics on arrays by map…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Aparapi Changelog
 
 ## 1.6.0
-
 * Add support for Local arguments in kernel functions
+* Add full support for OpenCL 1.2 atomic operations on arrays of integers.
+
+## 1.5.1
+
 
 ## 1.5.0
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,3 +42,4 @@ Below are some of the specific details of various contributions.
 * George Vinokhodov submited a fix for a bug regarding forward references.
 * Dmitriy Shabanov submited PR for inline array feature.
 * Luis Mendes submited PR to support passing functions arguments containing Local arrays - issue #79
+* Luis Mendes submited PR for issue #81 - Full OpenCL 1.2 atomics support with AtomicInteger 

--- a/src/main/java/com/aparapi/internal/model/ClassModel.java
+++ b/src/main/java/com/aparapi/internal/model/ClassModel.java
@@ -2769,7 +2769,12 @@ public class ClassModel {
    public void parse(Class<?> _class) throws ClassParseException {
 
       clazz = _class;
-      parse(_class.getClassLoader(), _class.getName());
+      //It is needed to load AtomicInteger class and Should also fix Issue #6 - NPE while getting Math.class
+      ClassLoader loader = _class.getClassLoader();
+      if (loader == null) {
+    	  loader = ClassLoader.getSystemClassLoader().getParent();
+      }
+      parse(loader, _class.getName());
    }
 
    /**

--- a/src/main/java/com/aparapi/internal/model/Entrypoint.java
+++ b/src/main/java/com/aparapi/internal/model/Entrypoint.java
@@ -63,6 +63,7 @@ import com.aparapi.internal.util.*;
 
 import java.lang.reflect.*;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.*;
 
 public class Entrypoint implements Cloneable {
@@ -174,7 +175,7 @@ public class Entrypoint implements Cloneable {
       try {
          field = _clazz.getDeclaredField(_name);
          final Class<?> type = field.getType();
-         if (type.isPrimitive() || type.isArray()) {
+         if (type.isPrimitive() || type.isArray() || type.equals(AtomicInteger.class)) {
             return field;
          }
          if (field.getAnnotation(Kernel.NoCL.class) != null) {
@@ -608,7 +609,7 @@ public class Entrypoint implements Cloneable {
                   if (arrayFieldModel != null) {
                      final Class<?> memberClass = arrayFieldModel.getClassWeAreModelling();
                      final int modifiers = memberClass.getModifiers();
-                     if (!Modifier.isFinal(modifiers)) {
+                     if (memberClass != AtomicInteger.class && !Modifier.isFinal(modifiers)) {
                         throw new ClassParseException(ClassParseException.TYPE.ACCESSEDOBJECTNONFINAL);
                      }
 

--- a/src/main/java/com/aparapi/internal/writer/KernelWriter.java
+++ b/src/main/java/com/aparapi/internal/writer/KernelWriter.java
@@ -64,6 +64,7 @@ import com.aparapi.internal.model.ClassModel.AttributePool.RuntimeAnnotationsEnt
 import com.aparapi.internal.model.ClassModel.AttributePool.RuntimeParameterAnnotationsEntry.ParameterInfo;
 import com.aparapi.internal.model.ClassModel.*;
 import com.aparapi.internal.model.ClassModel.ConstantPool.*;
+import com.aparapi.internal.model.ClassModel.ConstantPool.MethodReferenceEntry.Arg;
 
 import java.util.*;
 
@@ -193,6 +194,9 @@ public abstract class KernelWriter extends BlockWriter{
          return isLocal ? (cvtLongArrayToLong) : (cvtLongArrayToLongStar);
       } else if (_typeDesc.equals("[S") || _typeDesc.equals("short[]")) {
          return isLocal ? (cvtShortArrayToShort) : (cvtShortArrayToShortStar);
+      } else if (_typeDesc.equals("[Ljava/util/concurrent/atomic/AtomicInteger;") ||
+    		  _typeDesc.equals("[Ljava.util.concurrent.atomic.AtomicInteger;")) {
+    	 return (cvtIntArrayToIntStar);
       }
       // if we get this far, we haven't matched anything yet
       if (useClassModel) {
@@ -291,6 +295,12 @@ public abstract class KernelWriter extends BlockWriter{
             if (((intrinsicMapping == null) && (_methodCall instanceof VirtualMethodCall) && (!isIntrinsic)) || (arg != 0)) {
                write(", ");
             }
+
+            Arg methodArg = _methodEntry.getArgs()[arg];
+            if (!methodArg.isArray() && methodArg.getType().equals("Ljava/util/concurrent/atomic/AtomicInteger;")) {
+            	write("&");
+            }
+ 
             writeInstruction(_methodCall.getArg(arg));
          }
          write(")");
@@ -383,7 +393,10 @@ public abstract class KernelWriter extends BlockWriter{
 
          // If it is a converted array of objects, emit the struct param
          String className = null;
-         if (signature.startsWith("L")) {
+	 if (signature.equals("Ljava/util/concurrent/atomic/AtomicInteger;")) {
+            argLine.append("int");
+            thisStructLine.append("int");
+         } else if (signature.startsWith("L")) {
             // Turn Lcom/codegen/javalabs/opencl/demo/DummyOOA; into com_amd_javalabs_opencl_demo_DummyOOA for example
             className = (signature.substring(1, signature.length() - 1)).replace('/', '_');
             // if (logger.isLoggable(Level.FINE)) {
@@ -497,6 +510,12 @@ public abstract class KernelWriter extends BlockWriter{
       }
 
       if (usesAtomics) {
+         write("#define atomicGet(p) (*p)");
+         newLine();
+         
+         write("#define atomicSet(p, val) (*p=val)");
+         newLine();
+
          write("int atomicAdd(__global int *_arr, int _index, int _delta){");
          in();
          {

--- a/src/main/java/com/aparapi/internal/writer/KernelWriter.java
+++ b/src/main/java/com/aparapi/internal/writer/KernelWriter.java
@@ -194,8 +194,8 @@ public abstract class KernelWriter extends BlockWriter{
          return isLocal ? (cvtLongArrayToLong) : (cvtLongArrayToLongStar);
       } else if (_typeDesc.equals("[S") || _typeDesc.equals("short[]")) {
          return isLocal ? (cvtShortArrayToShort) : (cvtShortArrayToShortStar);
-      } else if (_typeDesc.equals("[Ljava/util/concurrent/atomic/AtomicInteger;") ||
-    		  _typeDesc.equals("[Ljava.util.concurrent.atomic.AtomicInteger;")) {
+      } else if ("[Ljava/util/concurrent/atomic/AtomicInteger;".equals(_typeDesc) ||
+    		  "[Ljava.util.concurrent.atomic.AtomicInteger;".equals(_typeDesc)) {
     	 return (cvtIntArrayToIntStar);
       }
       // if we get this far, we haven't matched anything yet
@@ -297,7 +297,7 @@ public abstract class KernelWriter extends BlockWriter{
             }
 
             Arg methodArg = _methodEntry.getArgs()[arg];
-            if (!methodArg.isArray() && methodArg.getType().equals("Ljava/util/concurrent/atomic/AtomicInteger;")) {
+            if (!methodArg.isArray() && "Ljava/util/concurrent/atomic/AtomicInteger;".equals(methodArg.getType())) {
             	write("&");
             }
  

--- a/src/test/java/com/aparapi/codegen/test/Atomic32PragmaTest.java
+++ b/src/test/java/com/aparapi/codegen/test/Atomic32PragmaTest.java
@@ -23,6 +23,8 @@ public class Atomic32PragmaTest extends com.aparapi.codegen.CodeGenJUnitBase {
 " #pragma OPENCL EXTENSION cl_khr_global_int32_extended_atomics : enable\n" +
 " #pragma OPENCL EXTENSION cl_khr_local_int32_base_atomics : enable\n" +
 " #pragma OPENCL EXTENSION cl_khr_local_int32_extended_atomics : enable\n" +
+" #define atomicGet(p) (*p)\n" + 
+" #define atomicSet(p, val) (*p=val)\n" +
 " int atomicAdd(__global int *_arr, int _index, int _delta){\n" +
 " return atomic_add(&_arr[_index], _delta);\n" +
 " }\n" +

--- a/src/test/java/com/aparapi/runtime/Issue81AtomicsSupportTest.java
+++ b/src/test/java/com/aparapi/runtime/Issue81AtomicsSupportTest.java
@@ -1,0 +1,1513 @@
+/**
+ * Copyright (c) 2016 - 2017 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aparapi.runtime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.aparapi.Kernel;
+import com.aparapi.Range;
+import com.aparapi.device.Device;
+import com.aparapi.device.JavaDevice;
+import com.aparapi.device.OpenCLDevice;
+import com.aparapi.internal.kernel.KernelManager;
+
+public class Issue81AtomicsSupportTest {
+
+    private static OpenCLDevice openCLDevice = null;
+
+    private static final int SIZE = 100;
+	private final static int LOCK_IDX = 3;
+	private final static int MAX_VAL_IDX = 0;
+	private final static int MAX_POS_LEFT_IDX = 1;
+	private final static int MAX_POS_RIGHT_IDX = 2;
+
+    private class CLKernelManager extends KernelManager {
+    	@Override
+    	protected List<Device.TYPE> getPreferredDeviceTypes() {
+    		return Arrays.asList(Device.TYPE.ACC, Device.TYPE.GPU, Device.TYPE.CPU);
+    	}
+    }
+    
+    private class JTPKernelManager extends KernelManager {
+    	private JTPKernelManager() {
+    		LinkedHashSet<Device> preferredDevices = new LinkedHashSet<Device>(1);
+    		preferredDevices.add(JavaDevice.THREAD_POOL);
+    		setDefaultPreferredDevices(preferredDevices);
+    	}
+    	@Override
+    	protected List<Device.TYPE> getPreferredDeviceTypes() {
+    		return Arrays.asList(Device.TYPE.JTP);
+    	}
+    }
+    
+    @Before
+    public void setUpBeforeClass() throws Exception {
+    	KernelManager.setKernelManager(new CLKernelManager());
+        Device device = KernelManager.instance().bestDevice();
+        assumeTrue (device != null && device instanceof OpenCLDevice);
+        openCLDevice = (OpenCLDevice) device;
+    }
+
+    @Test
+    public void issue81OpenCLExplicit() {
+    	final int in[] = new int[SIZE];
+    	
+    	final int[] out = new int[3];
+    	for (int i = 0; i < SIZE/2; i++) {
+    		in[i] = i;
+    		in[i + SIZE/2] = SIZE - i;
+    	}
+    	in[10] = SIZE;
+    	
+        final AtomicKernel kernel = new AtomicKernel(in, out);
+        try {
+	        final Range range = openCLDevice.createRange(SIZE/2, SIZE/2);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+        } finally {
+        	kernel.dispose();
+        }
+
+        assertEquals("Max value doesn't match", 100, out[0]);
+        assertTrue("Left max found at unexpected position: " + out[MAX_POS_LEFT_IDX], out[MAX_POS_LEFT_IDX] == 10 || out[MAX_POS_LEFT_IDX] == 50);
+        assertTrue("Right max found at unexpected position: " + out[MAX_POS_RIGHT_IDX], out[MAX_POS_RIGHT_IDX] == 100-10 || out[MAX_POS_RIGHT_IDX] == 100-50);
+    }
+    
+    @Test
+    public void issue81OpenCL() {
+    	final int in[] = new int[SIZE];
+    	
+    	final int[] out = new int[3];
+    	for (int i = 0; i < SIZE/2; i++) {
+    		in[i] = i;
+    		in[i + SIZE/2] = SIZE - i;
+    	}
+    	in[10] = SIZE;
+    	
+        final AtomicKernel kernel = new AtomicKernel(in, out);
+        try {
+	        final Range range = openCLDevice.createRange(SIZE/2, SIZE/2);
+	        kernel.execute(range);
+        } finally {
+        	kernel.dispose();
+        }
+
+        assertEquals("Max value doesn't match", 100, out[0]);
+        assertTrue("Left max found at unexpected position: " + out[MAX_POS_LEFT_IDX], out[MAX_POS_LEFT_IDX] == 10 || out[MAX_POS_LEFT_IDX] == 50);
+        assertTrue("Right max found at unexpected position: " + out[MAX_POS_RIGHT_IDX], out[MAX_POS_RIGHT_IDX] == 100-10 || out[MAX_POS_RIGHT_IDX] == 100-50);
+    }
+    
+    @Test
+    public void issue81JTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[SIZE];
+    	
+    	final int[] out = new int[3];
+    	for (int i = 0; i < SIZE/2; i++) {
+    		in[i] = i;
+    		in[i + SIZE/2] = SIZE - i;
+    	}
+    	in[10] = SIZE;
+    	
+        final AtomicKernel kernel = new AtomicKernel(in, out);
+        try {
+	        final Range range = device.createRange(SIZE/2, SIZE/2);
+	        kernel.execute(range);
+        } finally {
+        	kernel.dispose();
+        }
+        assertEquals("Max value doesn't match", 100, out[0]);
+        assertTrue("Left max found at unexpected position: " + out[MAX_POS_LEFT_IDX], out[MAX_POS_LEFT_IDX] == 10 || out[MAX_POS_LEFT_IDX] == 50);
+        assertTrue("Right max found at unexpected position: " + out[MAX_POS_RIGHT_IDX], out[MAX_POS_RIGHT_IDX] == 100-10 || out[MAX_POS_RIGHT_IDX] == 100-50);
+    }
+    
+    @Test
+    public void issue81BOpenCL() {
+    	final int in[] = new int[SIZE];
+    	final AtomicInteger[] out = new AtomicInteger[3];
+    	for (int i = 0; i < out.length; i++) {
+    		out[i] = new AtomicInteger(0);
+    	}
+    	for (int i = 0; i < SIZE/2; i++) {
+    		in[i] = i;
+    		in[i + SIZE/2] = SIZE - i;
+    	}
+    	in[10] = SIZE;
+    	
+        final AtomicBKernel kernel = new AtomicBKernel(in, out);
+        try {
+	        final Range range = openCLDevice.createRange(SIZE/2, SIZE/2);
+	        kernel.execute(range);
+        } finally {
+        	kernel.dispose();
+        }
+
+        assertEquals("Max value doesn't match", 100, out[0].get());
+        assertTrue("Left max found at unexpected position: " + out[MAX_POS_LEFT_IDX], out[MAX_POS_LEFT_IDX].get() == 10 || out[MAX_POS_LEFT_IDX].get() == 50);
+        assertTrue("Right max found at unexpected position: " + out[MAX_POS_RIGHT_IDX], out[MAX_POS_RIGHT_IDX].get() == 100-10 || out[MAX_POS_RIGHT_IDX].get() == 100-50);
+    }
+        
+    @Test
+    public void issue81BJTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[SIZE];
+    	final AtomicInteger[] out = new AtomicInteger[3];
+    	for (int i = 0; i < out.length; i++) {
+    		out[i] = new AtomicInteger(0);
+    	}
+    	for (int i = 0; i < SIZE/2; i++) {
+    		in[i] = i;
+    		in[i + SIZE/2] = SIZE - i;
+    	}
+    	in[10] = SIZE;
+    	
+        final AtomicBKernel kernel = new AtomicBKernel(in, out);
+        try {
+	        final Range range = device.createRange(SIZE/2, SIZE/2);
+	        kernel.execute(range);
+        } finally {
+        	kernel.dispose();
+        }
+        assertEquals("Max value doesn't match", 100, out[0].get());
+        assertTrue("Left max found at unexpected position: " + out[MAX_POS_LEFT_IDX], out[MAX_POS_LEFT_IDX].get() == 10 || out[MAX_POS_LEFT_IDX].get() == 50);
+        assertTrue("Right max found at unexpected position: " + out[MAX_POS_RIGHT_IDX], out[MAX_POS_RIGHT_IDX].get() == 100-10 || out[MAX_POS_RIGHT_IDX].get() == 100-50);
+    }    
+
+    
+    @Test
+    public void issue81AtomicAddOpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 10;
+    	in[1] = 20;
+    	
+    	final AtomicAdd kernel = new AtomicAdd(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0] + in[1], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicAddOpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 10;
+    	in[1] = 20;
+    	
+    	final AtomicAdd kernel = new AtomicAdd(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0] + in[1], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicAddJTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 10;
+    	in[1] = 20;
+    	
+    	final AtomicAdd kernel = new AtomicAdd(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0] + in[1], out[1]);
+    }
+
+    /**
+     * Kernel for single threaded validation of atomicAdd.
+     * Validates that a add operation is actually performed.
+     * @author lpnm
+     *
+     */
+    private static final class AtomicAdd extends Kernel {
+    	private int in[];
+    	private int out[];
+    	
+    	public AtomicAdd(int[] in, int out[]) {
+    		this.in = in;
+    		this.out = out;
+    		atomicValues = new AtomicInteger[2];
+    		atomicValues[0] = new AtomicInteger(0);
+    		atomicValues[1] = new AtomicInteger(0);
+    	}
+
+    	@Local
+    	private AtomicInteger atomicValues[];
+    	
+		@Override
+		public void run() {
+			atomicSet(atomicValues[0], in[0]);
+			out[0] = atomicAdd(atomicValues[0], in[1]);
+			out[1] = atomicGet(atomicValues[0]);
+		}
+    }
+
+    @Test
+    public void issue81AtomicSubOpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 10;
+    	in[1] = 20;
+    	
+    	final AtomicSub kernel = new AtomicSub(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0] - in[1], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicSubOpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 10;
+    	in[1] = 20;
+    	
+    	final AtomicSub kernel = new AtomicSub(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0] - in[1], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicSubJTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 10;
+    	in[1] = 20;
+    	
+    	final AtomicSub kernel = new AtomicSub(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0] - in[1], out[1]);
+    }
+    
+    /**
+     * Kernel for single threaded validation of atomicSub.
+     * Validates that a subtraction operation is actually performed.
+     * @author lpnm
+     *
+     */
+    private static final class AtomicSub extends Kernel {
+    	private int in[];
+    	private int out[];
+    	
+    	public AtomicSub(int[] in, int out[]) {
+    		this.in = in;
+    		this.out = out;
+    		atomicValues = new AtomicInteger[2];
+    		atomicValues[0] = new AtomicInteger(0);
+    		atomicValues[1] = new AtomicInteger(0);
+    	}
+
+    	@Local
+    	private AtomicInteger atomicValues[];
+    	
+		@Override
+		public void run() {
+			atomicSet(atomicValues[0], in[0]);
+			out[0] = atomicSub(atomicValues[0], in[1]);
+			out[1] = atomicGet(atomicValues[0]);			
+		}
+
+    }
+
+    @Test
+    public void issue81AtomicXchgOpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 10;
+    	in[1] = 20;
+    	
+    	final AtomicXchg kernel = new AtomicXchg(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[1], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicXchgOpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 10;
+    	in[1] = 20;
+    	
+    	final AtomicXchg kernel = new AtomicXchg(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[1], out[1]);
+    }
+    
+    @Test
+    public void issue81AtomicXchgJTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 10;
+    	in[1] = 20;
+    	
+    	final AtomicXchg kernel = new AtomicXchg(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[1], out[1]);
+    }
+
+    /**
+     * Kernel for single threaded validation of atomicXchg.
+     * Validates that a value exchange operation is actually performed.
+     * @author lpnm
+     *
+     */
+    private static final class AtomicXchg extends Kernel {
+    	private int in[];
+    	private int out[];
+    	
+    	public AtomicXchg(int[] in, int out[]) {
+    		this.in = in;
+    		this.out = out;
+    		atomicValues = new AtomicInteger[2];
+    		atomicValues[0] = new AtomicInteger(0);
+    		atomicValues[1] = new AtomicInteger(0);
+    	}
+
+    	@Local
+    	private AtomicInteger atomicValues[];
+    	
+		@Override
+		public void run() {
+			atomicSet(atomicValues[0], in[0]);
+			out[0] = atomicXchg(atomicValues[0], in[1]);
+			out[1] = atomicGet(atomicValues[0]);
+		}
+
+    }
+    
+    @Test
+    public void issue81AtomicIncOpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[1];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	
+    	final AtomicInc kernel = new AtomicInc(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0] + 1, out[1]);
+    }
+
+    @Test
+    public void issue81AtomicIncOpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[1];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	
+    	final AtomicInc kernel = new AtomicInc(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0] + 1, out[1]);
+    }
+    
+    @Test
+    public void issue81AtomicInc() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[1];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	
+    	final AtomicInc kernel = new AtomicInc(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0] + 1, out[1]);
+    }
+
+    /**
+     * Kernel for single threaded validation of atomicInc.
+     * Validates that an increment operation is actually performed.
+     * @author lpnm
+     *
+     */
+    private static final class AtomicInc extends Kernel {
+    	private int in[];
+    	private int out[];
+    	
+    	public AtomicInc(int[] in, int out[]) {
+    		this.in = in;
+    		this.out = out;
+    		atomicValues = new AtomicInteger[2];
+    		atomicValues[0] = new AtomicInteger(0);
+    		atomicValues[1] = new AtomicInteger(0);
+    	}
+
+    	@Local
+    	private AtomicInteger atomicValues[];
+    	
+		@Override
+		public void run() {
+			atomicSet(atomicValues[0], in[0]);
+			out[0] = atomicInc(atomicValues[0]);
+			out[1] = atomicGet(atomicValues[0]);
+		}
+
+    }
+
+    @Test
+    public void issue81AtomicDecOpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[1];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	
+    	final AtomicDec kernel = new AtomicDec(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0] - 1, out[1]);
+    }
+
+    @Test
+    public void issue81AtomicDecOpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[1];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	
+    	final AtomicDec kernel = new AtomicDec(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0] - 1, out[1]);
+    }
+
+    @Test
+    public void issue81AtomicDecJTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[1];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	
+    	final AtomicDec kernel = new AtomicDec(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0] - 1, out[1]);
+    }
+
+    /**
+     * Kernel for single threaded validation of atomicDec.
+     * Validates that a decrement operation is actually performed.
+     * @author lpnm
+     *
+     */
+    private static final class AtomicDec extends Kernel {
+    	private int in[];
+    	private int out[];
+    	
+    	public AtomicDec(int[] in, int out[]) {
+    		this.in = in;
+    		this.out = out;
+    		atomicValues = new AtomicInteger[2];
+    		atomicValues[0] = new AtomicInteger(0);
+    		atomicValues[1] = new AtomicInteger(0);
+    	}
+
+    	@Local
+    	private AtomicInteger atomicValues[];
+    	
+		@Override
+		public void run() {
+			atomicSet(atomicValues[0], in[0]);
+			out[0] = atomicDec(atomicValues[0]);
+			out[1] = atomicGet(atomicValues[0]);
+		}
+
+    }
+
+    @Test
+    public void issue81AtomicCmpXchg1OpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[3];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 50;
+    	in[2] = 100;
+    	
+    	final AtomicCmpXchg kernel = new AtomicCmpXchg(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[2], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicCmpXchg1OpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[3];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 50;
+    	in[2] = 100;
+    	
+    	final AtomicCmpXchg kernel = new AtomicCmpXchg(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[2], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicCmpXchg1JTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[3];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 50;
+    	in[2] = 100;
+    	
+    	final AtomicCmpXchg kernel = new AtomicCmpXchg(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[2], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicCmpXchg2OpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[3];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 51;
+    	in[2] = 100;
+    	
+    	final AtomicCmpXchg kernel = new AtomicCmpXchg(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicCmpXchg2OpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[3];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 51;
+    	in[2] = 100;
+    	
+    	final AtomicCmpXchg kernel = new AtomicCmpXchg(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicCmpXchg2JTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[3];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 51;
+    	in[2] = 100;
+    	
+    	final AtomicCmpXchg kernel = new AtomicCmpXchg(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0], out[1]);
+    }
+
+    /**
+     * Kernel for single threaded validation of atomicCmpXchg.
+     * Validates that a cmpXchg operation is actually performed.
+     * @author lpnm
+     *
+     */
+    private static final class AtomicCmpXchg extends Kernel {
+    	private int in[];
+    	private int out[];
+    	
+    	public AtomicCmpXchg(int[] in, int out[]) {
+    		this.in = in;
+    		this.out = out;
+    		atomicValues = new AtomicInteger[2];
+    		atomicValues[0] = new AtomicInteger(0);
+    		atomicValues[1] = new AtomicInteger(0);
+    	}
+
+    	@Local
+    	private AtomicInteger atomicValues[];
+    	
+		@Override
+		public void run() {
+			atomicSet(atomicValues[0], in[0]);
+			out[0] = atomicCmpXchg(atomicValues[0], in[1], in[2]);
+			out[1] = atomicGet(atomicValues[0]);
+		}
+
+    }
+
+    @Test
+    public void issue81AtomicMin1OpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 49;
+    	
+    	final AtomicMin kernel = new AtomicMin(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[1], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicMin1OpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 49;
+    	
+    	final AtomicMin kernel = new AtomicMin(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[1], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicMin1JTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 49;
+    	
+    	final AtomicMin kernel = new AtomicMin(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[1], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicMin2OpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 51;
+    	
+    	final AtomicMin kernel = new AtomicMin(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicMin2OpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 51;
+    	
+    	final AtomicMin kernel = new AtomicMin(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicMin2JTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 51;
+    	
+    	final AtomicMin kernel = new AtomicMin(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0], out[1]);
+    }
+
+    /**
+     * Kernel for single threaded validation of atomicMin.
+     * Validates that a min operation is actually performed.
+     * @author lpnm
+     *
+     */
+    private static final class AtomicMin extends Kernel {
+    	private int in[];
+    	private int out[];
+    	
+    	public AtomicMin(int[] in, int out[]) {
+    		this.in = in;
+    		this.out = out;
+    		atomicValues = new AtomicInteger[2];
+    		atomicValues[0] = new AtomicInteger(0);
+    		atomicValues[1] = new AtomicInteger(0);
+    	}
+
+    	@Local
+    	private AtomicInteger atomicValues[];
+    	
+		@Override
+		public void run() {
+			atomicSet(atomicValues[0], in[0]);
+			out[0] = atomicMin(atomicValues[0], in[1]);
+			out[1] = atomicGet(atomicValues[0]);			
+		}
+
+    }
+
+    @Test
+    public void issue81AtomicMax1OpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 51;
+    	
+    	final AtomicMax kernel = new AtomicMax(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[1], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicMax1OpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 51;
+    	
+    	final AtomicMax kernel = new AtomicMax(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[1], out[1]);
+    }
+    
+    @Test
+    public void issue81AtomicMax1JTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 51;
+    	
+    	final AtomicMax kernel = new AtomicMax(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[1], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicMax2OpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 49;
+    	
+    	final AtomicMax kernel = new AtomicMax(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicMax2OpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 49;
+    	
+    	final AtomicMax kernel = new AtomicMax(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0], out[1]);
+    }
+
+    @Test
+    public void issue81AtomicMax2JTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 50;
+    	in[1] = 49;
+    	
+    	final AtomicMax kernel = new AtomicMax(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", in[0], out[1]);
+    }
+
+    /**
+     * Kernel for single threaded validation of atomicMax.
+     * Validates that a max operation is actually performed.
+     * @author lpnm
+     *
+     */
+    private static final class AtomicMax extends Kernel {
+    	private int in[];
+    	private int out[];
+    	
+    	public AtomicMax(int[] in, int out[]) {
+    		this.in = in;
+    		this.out = out;
+    		atomicValues = new AtomicInteger[2];
+    		atomicValues[0] = new AtomicInteger(0);
+    		atomicValues[1] = new AtomicInteger(0);
+    	}
+
+    	@Local
+    	private AtomicInteger atomicValues[];
+    	
+		@Override
+		public void run() {
+			atomicSet(atomicValues[0], in[0]);
+			out[0] = atomicMax(atomicValues[0], in[1]);
+			out[1] = atomicGet(atomicValues[0]);
+		}
+
+    }
+
+    @Test
+    public void issue81AtomicAndOpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 0xf1;
+    	in[1] = 0x8f;
+    	
+    	final AtomicAnd kernel = new AtomicAnd(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", 0x81, out[1]);
+    }
+
+    @Test
+    public void issue81AtomicAndOpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 0xf1;
+    	in[1] = 0x8f;
+    	
+    	final AtomicAnd kernel = new AtomicAnd(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", 0x81, out[1]);
+    }
+    
+    @Test
+    public void issue81AtomicAndJTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 0xf1;
+    	in[1] = 0x8f;
+    	
+    	final AtomicAnd kernel = new AtomicAnd(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", 0x81, out[1]);
+    }
+    
+    /**
+     * Kernel for single threaded validation of atomicXor.
+     * Validates that an and operation is actually performed.
+     * @author lpnm
+     *
+     */
+    private static final class AtomicAnd extends Kernel {
+    	private int in[];
+    	private int out[];
+    	
+    	public AtomicAnd(int[] in, int out[]) {
+    		this.in = in;
+    		this.out = out;
+    		atomicValues = new AtomicInteger[2];
+    		atomicValues[0] = new AtomicInteger(0);
+    		atomicValues[1] = new AtomicInteger(0);
+    	}
+
+    	@Local
+    	private AtomicInteger atomicValues[];
+    	
+		@Override
+		public void run() {
+			atomicSet(atomicValues[0], in[0]);
+			out[0] = atomicAnd(atomicValues[0], in[1]);
+			out[1] = atomicGet(atomicValues[0]);
+		}
+
+    }
+
+    @Test
+    public void issue81AtomicOrOpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 0x80;
+    	in[1] = 0x02;
+    	
+    	final AtomicOr kernel = new AtomicOr(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", 0x82, out[1]);
+    }
+
+    @Test
+    public void issue81AtomicOrOpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 0x80;
+    	in[1] = 0x02;
+    	
+    	final AtomicOr kernel = new AtomicOr(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", 0x82, out[1]);
+    }
+
+    @Test
+    public void issue81AtomicOrJTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 0x80;
+    	in[1] = 0x02;
+    	
+    	final AtomicOr kernel = new AtomicOr(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", 0x82, out[1]);
+    }
+    
+    /**
+     * Kernel for single threaded validation of atomicOr.
+     * Validates that an or operation is actually performed.
+     * @author lpnm
+     *
+     */
+    private static final class AtomicOr extends Kernel {
+    	private int in[];
+    	private int out[];
+    	
+    	public AtomicOr(int[] in, int out[]) {
+    		this.in = in;
+    		this.out = out;
+    		atomicValues = new AtomicInteger[2];
+    		atomicValues[0] = new AtomicInteger(0);
+    		atomicValues[1] = new AtomicInteger(0);
+    	}
+
+    	@Local
+    	private AtomicInteger atomicValues[];
+    	
+		@Override
+		public void run() {
+			atomicSet(atomicValues[0], in[0]);
+			out[0] = atomicOr(atomicValues[0], in[1]);
+			out[1] = atomicGet(atomicValues[0]);
+		}
+
+    }
+
+    @Test
+    public void issue81AtomicXorOpenCLExplicit() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 0xf1;
+    	in[1] = 0x8f;
+    	
+    	final AtomicXor kernel = new AtomicXor(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.setExplicit(true);
+	        kernel.put(in);
+	        kernel.execute(range);
+	        kernel.get(out);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", 0x7e, out[1]);
+    }
+
+    @Test
+    public void issue81AtomicXorOpenCL() {
+    	Device openCLDevice = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 0xf1;
+    	in[1] = 0x8f;
+    	
+    	final AtomicXor kernel = new AtomicXor(in, out);
+    	try {
+	    	final Range range = openCLDevice.createRange(1,1);
+	        kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", 0x7e, out[1]);
+    }
+    
+    @Test
+    public void issue81AtomicXorJTP() {
+    	KernelManager.setKernelManager(new JTPKernelManager());
+    	Device device = KernelManager.instance().bestDevice();
+    	final int in[] = new int[2];
+    	final int[] out = new int[2];
+    	in[0] = 0xf1;
+    	in[1] = 0x8f;
+    	
+    	final AtomicXor kernel = new AtomicXor(in, out);
+    	try {
+	    	final Range range = device.createRange(1,1);
+	    	kernel.execute(range);
+    	} finally {
+    		kernel.dispose();
+    	}
+    	assertEquals("Old value doesn't match", in[0], out[0]);
+    	assertEquals("Final value doesn't match", 0x7e, out[1]);
+    }
+    
+    /**
+     * Kernel for single threaded validation of atomicXor.
+     * Validates that a xor operation is actually performed.
+     * @author lpnm
+     *
+     */
+    private static final class AtomicXor extends Kernel {
+    	private int in[];
+    	private int out[];
+    	
+    	public AtomicXor(int[] in, int out[]) {
+    		this.in = in;
+    		this.out = out;
+    		atomicValues = new AtomicInteger[2];
+    		atomicValues[0] = new AtomicInteger(0);
+    		atomicValues[1] = new AtomicInteger(0);
+    	}
+
+    	@Local
+    	private AtomicInteger atomicValues[];
+    	
+		@Override
+		public void run() {
+			atomicSet(atomicValues[0], in[0]);
+			out[0] = atomicXor(atomicValues[0], in[1]);
+			out[1] = atomicGet(atomicValues[0]);
+		}
+    }
+
+
+    
+    private static final class AtomicKernel extends Kernel {    	
+    	private int in[];
+    	private int out[];
+    	
+    	@Local
+    	private final AtomicInteger maxs[] = new AtomicInteger[4];
+    	    	
+    	public AtomicKernel(int[] in, int[] out) {
+    		this.in = in;
+    		this.out = out;
+    		for (int idx = 0; idx < 4; idx++) {
+    			maxs[idx] = new AtomicInteger(0);
+    		}
+    	}
+    	
+        @Override
+        public void run() {
+        	final int localId = getLocalId(0);
+        	
+        	//Ensure that initial values are initialized... this must be enforced for OpenCL, otherwise they may contain
+        	//random values, as for Java, it is not needed, as they are already initialized in AtomicInteger constructor.
+        	//Since this is Aparapi, it must be initialized on both platforms. 
+        	if (localId == 0) {
+	        	atomicSet(maxs[MAX_VAL_IDX], 0);
+	        	atomicSet(maxs[LOCK_IDX], 0);
+        	}
+        	//Ensure all threads start with the initialized atomic max value and lock.
+        	localBarrier();
+        	
+        	final int offset = localId * 2;
+    		int localMaxVal = 0;
+    		int localMaxPosFromLeft = 0;
+    		int localMaxPosFromRight = 0;
+    		for (int i = 0; i < 2; i++) {
+    			localMaxVal = max(in[offset + i], localMaxVal);
+    			if (localMaxVal == in[offset + i]) {
+    				localMaxPosFromLeft = offset + i;
+    				localMaxPosFromRight = SIZE - (offset + i);
+    			}
+    		}
+    		
+        	atomicMax(maxs[MAX_VAL_IDX], localMaxVal);
+    		//Ensure all threads have updated the atomic maxs[MAX_VAL_IDX]
+        	localBarrier();
+        	
+        	int maxValue = atomicGet(maxs[MAX_VAL_IDX]);
+        	if (maxValue == localMaxVal) {
+        		//Only the threads that have the max value will reach this point, however the max value, may
+        		//occur at multiple indices of the input array.
+        		if (atomicXchg(maxs[LOCK_IDX], 0xff) == 0) {
+        			//Only one of the threads with the max value will get here, thus ensuring consistent update of
+        			//maxPosFromRight and maxPosFromLeft.
+        			atomicSet(maxs[MAX_POS_LEFT_IDX], localMaxPosFromLeft);
+        			atomicSet(maxs[MAX_POS_RIGHT_IDX], localMaxPosFromRight);
+        			out[MAX_VAL_IDX] = maxValue;
+        			out[MAX_POS_LEFT_IDX] = atomicGet(maxs[MAX_POS_LEFT_IDX]);
+        			out[MAX_POS_RIGHT_IDX] = localMaxPosFromRight;
+        		}
+        	}
+        }
+    }
+    
+    private static final class AtomicBKernel extends Kernel {    	
+    	private int in[];
+    	private AtomicInteger out[];
+    	
+    	@Local
+    	private final AtomicInteger maxs[] = new AtomicInteger[4];
+    	    	
+    	public AtomicBKernel(int[] in, AtomicInteger[] out) {
+    		this.in = in;
+    		this.out = out;
+    		for (int idx = 0; idx < 4; idx++) {
+    			maxs[idx] = new AtomicInteger(0);
+    		}
+    	}
+    	
+        @Override
+        public void run() {
+        	final int localId = getLocalId(0);
+        	
+        	//Ensure that initial values are initialized... this must be enforced for OpenCL, otherwise they may contain
+        	//random values, as for Java, it is not needed, as they are already initialized in AtomicInteger constructor.
+        	//Since this is Aparapi, it must be initialized on both platforms. 
+        	if (localId == 0) {
+	        	atomicSet(maxs[MAX_VAL_IDX], 0);
+	        	atomicSet(maxs[LOCK_IDX], 0);
+        	}
+        	//Ensure all threads start with the initialized atomic max value and lock.
+        	localBarrier();
+        	
+        	final int offset = localId * 2;
+    		int localMaxVal = 0;
+    		int localMaxPosFromLeft = 0;
+    		int localMaxPosFromRight = 0;
+    		for (int i = 0; i < 2; i++) {
+    			localMaxVal = max(in[offset + i], localMaxVal);
+    			if (localMaxVal == in[offset + i]) {
+    				localMaxPosFromLeft = offset + i;
+    				localMaxPosFromRight = SIZE - (offset + i);
+    			}
+    		}
+    		
+        	atomicMax(maxs[MAX_VAL_IDX], localMaxVal);
+    		//Ensure all threads have updated the atomic maxs[MAX_VAL_IDX]
+        	localBarrier();
+        	
+        	int maxValue = atomicGet(maxs[MAX_VAL_IDX]);
+        	if (maxValue == localMaxVal) {
+        		//Only the threads that have the max value will reach this point, however the max value, may
+        		//occur at multiple indices of the input array.
+        		if (atomicXchg(maxs[LOCK_IDX], 0xff) == 0) {
+        			//Only one of the threads with the max value will get here, thus ensuring consistent update of
+        			//maxPosFromRight and maxPosFromLeft.
+        			atomicSet(maxs[MAX_POS_LEFT_IDX], localMaxPosFromLeft);
+        			atomicSet(maxs[MAX_POS_RIGHT_IDX], localMaxPosFromRight);
+        			atomicSet(out[MAX_VAL_IDX], maxValue);
+        			atomicSet(out[MAX_POS_LEFT_IDX], atomicGet(maxs[MAX_POS_LEFT_IDX]));
+        			atomicSet(out[MAX_POS_RIGHT_IDX], localMaxPosFromRight);
+        		}
+        	}
+        }
+    }
+
+}


### PR DESCRIPTION
…ping Java Arrays of AtomicIntegers (refs #81)

Provides support for full OpenCL 1.2 atomics on array of integers as described in #81 

[Issue81AtomicsSupport 8a0692f] Update: Add complete suppport for OpenCL 1.2 atomics on arrays by mapping Java Arrays of AtomicIntegers (refs #81)
 8 files changed, 1803 insertions(+), 10 deletions(-)
 create mode 100644 src/test/java/com/aparapi/runtime/Issue81AtomicsSupportTest.java
