### PR TITLE
Update: Fully support OpenCL 1.2 barrier() - localBarrier(),  globalBarrier() and localGlobalBarrier() (refs 84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Aparapi Changelog
 
-## 1.6.1
+## 1.7.0
+* Fully support OpenCL 1.2 barrier() - localBarrier(),  globalBarrier() and localGlobalBarrier()
 
 ## 1.6.0
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,3 +43,4 @@ Below are some of the specific details of various contributions.
 * Dmitriy Shabanov submited PR for inline array feature.
 * Luis Mendes submited PR to support passing functions arguments containing Local arrays - issue #79
 * Luis Mendes submited PR for issue #81 - Full OpenCL 1.2 atomics support with AtomicInteger 
+* Luis Mendes submited PR for issue #84 - Fully support OpenCL 1.2 barrier() - localBarrier(),  globalBarrier() and localGlobalBarrier()

--- a/src/main/java/com/aparapi/Kernel.java
+++ b/src/main/java/com/aparapi/Kernel.java
@@ -2414,7 +2414,17 @@ public abstract class Kernel implements Cloneable {
    }
 
    /**
-    * Wait for all kernels in the current group to rendezvous at this call before continuing execution.
+    * Wait for all kernels in the current work group to rendezvous at this call before continuing execution.<br/> 
+    * It will also enforce memory ordering, such that modifications made by each thread in the work-group, to the memory,
+    * before entering into this barrier call will be visible by all threads leaving the barrier.
+    * <br/>
+    * <br/><b>Note1: </b>In OpenCL will execute as barrier(CLK_LOCAL_MEM_FENCE), which will have a different behavior than in Java,
+    * because it will only guarantee visibility of modifications made to <b>local memory space</b> to all threads leaving the barrier.
+    * <br/>
+    * <br/><b>Note2: </b>In OpenCL it is required that all threads must enter the same if blocks and must iterate
+    * the same number of times in all loops (for, while, ...).
+    * <br/>
+    * <br/><b>Note3: </b> Java version is identical to localBarrier(), globalBarrier() and localGlobalBarrier()
     *
     * @annotion Experimental
     */
@@ -2425,20 +2435,50 @@ public abstract class Kernel implements Cloneable {
    }
 
    /**
-    * Wait for all kernels in the current group to rendezvous at this call before continuing execution.
-    *
-    *
-    * Java version is identical to localBarrier()
+    * Wait for all kernels in the current work group to rendezvous at this call before continuing execution.<br/> 
+    * It will also enforce memory ordering, such that modifications made by each thread in the work-group, to the memory,
+    * before entering into this barrier call will be visible by all threads leaving the barrier.
+    * <br/> 
+    * <br/><b>Note1: </b>In OpenCL will execute as barrier(CLK_GLOBAL_MEM_FENCE), which will have a different behavior than in Java,
+    * because it will only guarantee visibility of modifications made to <b>global memory space</b> to all threads,
+    * in the work group, leaving the barrier.
+    * <br/>
+    * <br/><b>Note2: </b>In OpenCL it is required that all threads must enter the same if blocks and must iterate
+    * the same number of times in all loops (for, while, ...).
+    * <br/>
+    * <br/><b>Note3: </b> Java version is identical to localBarrier(), globalBarrier() and localGlobalBarrier()
     *
     * @annotion Experimental
-    * @deprecated
     */
    @OpenCLDelegate
    @Experimental
-   @Deprecated
-   protected final void globalBarrier() throws DeprecatedException {
-      throw new DeprecatedException(
-            "Kernel.globalBarrier() has been deprecated. It was based an incorrect understanding of OpenCL functionality.");
+   protected final void globalBarrier() {
+	   kernelState.awaitOnLocalBarrier();
+   }
+
+   /**
+    * Wait for all kernels in the current work group to rendezvous at this call before continuing execution.<br/> 
+    * It will also enforce memory ordering, such that modifications made by each thread in the work-group, to the memory,
+    * before entering into this barrier call will be visible by all threads leaving the barrier.
+    * <br/> 
+    * <br/><b>Note1: </b>When in doubt, use this barrier instead of localBarrier() or globalBarrier(), despite the possible
+    * performance loss.
+    * <br/>
+    * <br/><b>Note2: </b>In OpenCL will execute as barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE), which will 
+    * have the same behavior than in Java, because it will guarantee the visibility of modifications made to 
+    * <b>any of the memory spaces</b> to all threads, in the work group, leaving the barrier.
+    * <br/>
+    * <br/><b>Note3: </b>In OpenCL it is required that all threads must enter the same if blocks and must iterate
+    * the same number of times in all loops (for, while, ...).
+    * <br/>
+    * <br/><b>Note4: </b> Java version is identical to localBarrier(), globalBarrier() and localGlobalBarrier()
+    *
+    * @annotion Experimental
+    */
+   @OpenCLDelegate
+   @Experimental
+   protected final void localGlobalBarrier() {
+	   kernelState.awaitOnLocalBarrier();
    }
 
    @OpenCLMapping(mapTo = "hypot")

--- a/src/main/java/com/aparapi/Kernel.java
+++ b/src/main/java/com/aparapi/Kernel.java
@@ -2418,7 +2418,7 @@ public abstract class Kernel implements Cloneable {
     * It will also enforce memory ordering, such that modifications made by each thread in the work-group, to the memory,
     * before entering into this barrier call will be visible by all threads leaving the barrier.
     * <br/>
-    * <br/><b>Note1: </b>In OpenCL will execute as barrier(CLK_LOCAL_MEM_FENCE), which will have a different behavior than in Java,
+    * <br/><b>Note1: </b>In OpenCL will execute as barrier(CLK_LOCAL_MEM_FENCE), which will have a different behaviour than in Java,
     * because it will only guarantee visibility of modifications made to <b>local memory space</b> to all threads leaving the barrier.
     * <br/>
     * <br/><b>Note2: </b>In OpenCL it is required that all threads must enter the same if blocks and must iterate
@@ -2439,7 +2439,7 @@ public abstract class Kernel implements Cloneable {
     * It will also enforce memory ordering, such that modifications made by each thread in the work-group, to the memory,
     * before entering into this barrier call will be visible by all threads leaving the barrier.
     * <br/> 
-    * <br/><b>Note1: </b>In OpenCL will execute as barrier(CLK_GLOBAL_MEM_FENCE), which will have a different behavior than in Java,
+    * <br/><b>Note1: </b>In OpenCL will execute as barrier(CLK_GLOBAL_MEM_FENCE), which will have a different behaviour; than in Java,
     * because it will only guarantee visibility of modifications made to <b>global memory space</b> to all threads,
     * in the work group, leaving the barrier.
     * <br/>
@@ -2465,7 +2465,7 @@ public abstract class Kernel implements Cloneable {
     * performance loss.
     * <br/>
     * <br/><b>Note2: </b>In OpenCL will execute as barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE), which will 
-    * have the same behavior than in Java, because it will guarantee the visibility of modifications made to 
+    * have the same behaviour than in Java, because it will guarantee the visibility of modifications made to 
     * <b>any of the memory spaces</b> to all threads, in the work group, leaving the barrier.
     * <br/>
     * <br/><b>Note3: </b>In OpenCL it is required that all threads must enter the same if blocks and must iterate

--- a/src/main/java/com/aparapi/internal/writer/KernelWriter.java
+++ b/src/main/java/com/aparapi/internal/writer/KernelWriter.java
@@ -160,6 +160,8 @@ public abstract class KernelWriter extends BlockWriter{
       javaToCLIdentifierMap.put("localBarrier()V", "barrier(CLK_LOCAL_MEM_FENCE)");
 
       javaToCLIdentifierMap.put("globalBarrier()V", "barrier(CLK_GLOBAL_MEM_FENCE)");
+      
+      javaToCLIdentifierMap.put("localGlobalBarrier()V", "barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE)");
    }
 
    /**

--- a/src/test/java/com/aparapi/runtime/Issue84BarrierSupportTest.java
+++ b/src/test/java/com/aparapi/runtime/Issue84BarrierSupportTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package pt.ist.ceris.vipivist.tests;
+package com.aparapi.runtime;
 
 import com.aparapi.Kernel;
 import com.aparapi.Range;

--- a/src/test/java/com/aparapi/runtime/Issue84BarrierSupportTest.java
+++ b/src/test/java/com/aparapi/runtime/Issue84BarrierSupportTest.java
@@ -1,0 +1,303 @@
+/**
+ * Copyright (c) 2016 - 2017 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pt.ist.ceris.vipivist.tests;
+
+import com.aparapi.Kernel;
+import com.aparapi.Range;
+import com.aparapi.device.Device;
+import com.aparapi.device.JavaDevice;
+import com.aparapi.device.OpenCLDevice;
+import com.aparapi.internal.kernel.KernelManager;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class Issue84BarrierSupportTest {
+    private static OpenCLDevice openCLDevice = null;
+    private static int SIZE;
+    private int[] targetArray;
+
+    private class CLKernelManager extends KernelManager {
+    	@Override
+    	protected List<Device.TYPE> getPreferredDeviceTypes() {
+    		return Arrays.asList(Device.TYPE.ACC, Device.TYPE.GPU, Device.TYPE.CPU);
+    	}
+    }
+
+    private class JTPKernelManager extends KernelManager {
+    	private JTPKernelManager() {
+    		LinkedHashSet<Device> preferredDevices = new LinkedHashSet<Device>(1);
+    		preferredDevices.add(JavaDevice.THREAD_POOL);
+    		setDefaultPreferredDevices(preferredDevices);
+    	}
+    	@Override
+    	protected List<Device.TYPE> getPreferredDeviceTypes() {
+    		return Arrays.asList(Device.TYPE.JTP);
+    	}
+    }
+
+    @Before
+    public void setUpBefore() throws Exception {
+    	KernelManager.setKernelManager(new CLKernelManager());
+        Device device = KernelManager.instance().bestDevice();
+        assumeTrue (device != null && device instanceof OpenCLDevice);
+        openCLDevice = (OpenCLDevice) device;
+        SIZE = openCLDevice.getMaxWorkGroupSize();
+    }
+
+    @Test
+    public void testBarrier1() {
+    	System.out.println("Executing on device: " + openCLDevice.getShortDescription() + " - " + openCLDevice.getName());
+        final Barrrier1Kernel kernel = new Barrrier1Kernel(SIZE);
+        try {
+	        final Range range = openCLDevice.createRange(SIZE, SIZE);
+	        targetArray = initInputArray();
+	        kernel.setExplicit(false);
+	        kernel.setArray(targetArray);
+	        kernel.execute(range);
+	        assertTrue(validate());
+        } finally {
+        	kernel.dispose();
+        }
+    }
+    
+    @Test
+    public void testBarrier1Explicit() {
+    	System.out.println("Executing on device: " + openCLDevice.getShortDescription() + " - " + openCLDevice.getName());
+        final Barrrier1Kernel kernel = new Barrrier1Kernel(SIZE);
+        try {
+	        final Range range = openCLDevice.createRange(SIZE, SIZE);
+	        targetArray = initInputArray();
+	        kernel.setExplicit(true);
+	        kernel.setArray(targetArray);
+	        kernel.put(targetArray);
+	        kernel.execute(range);
+	        kernel.get(targetArray);
+	        assertTrue(validate());
+        } finally {
+        	kernel.dispose();
+        }
+    }
+
+    @Test
+    public void testBarrier1JTP() {
+    	SIZE = 256;
+    	KernelManager.setKernelManager(new JTPKernelManager());
+        Device device = KernelManager.instance().bestDevice();
+        System.out.println("Executing on device: " + device.getShortDescription());
+        assumeTrue (device != null && device instanceof JavaDevice);
+
+        final Barrrier1Kernel kernel = new Barrrier1Kernel(SIZE);
+        try {
+	        final Range range = device.createRange(SIZE, SIZE);
+	        targetArray = initInputArray();
+	        kernel.setExplicit(false);
+	        kernel.setArray(targetArray);
+	        kernel.execute(range);
+	        assertTrue(validate());
+        } finally {
+        	kernel.dispose();
+        }
+    }
+
+    @Test
+    public void testBarrier2() {
+    	System.out.println("Executing on device: " + openCLDevice.getShortDescription() + " - " + openCLDevice.getName());
+        final Barrrier2Kernel kernel = new Barrrier2Kernel(SIZE);
+        try {
+	        final Range range = openCLDevice.createRange(SIZE, SIZE);
+	        targetArray = initInputArray();
+	        kernel.setExplicit(false);
+	        kernel.setArray(targetArray);
+	        kernel.execute(range);
+	        assertTrue(validate());
+        } finally {
+        	kernel.dispose();
+        }
+    }
+    
+    @Test
+    public void testBarrier2Explicit() {
+    	System.out.println("Executing on device: " + openCLDevice.getShortDescription() + " - " + openCLDevice.getName());
+        final Barrrier2Kernel kernel = new Barrrier2Kernel(SIZE);
+        try {
+	        final Range range = openCLDevice.createRange(SIZE, SIZE);
+	        targetArray = initInputArray();
+	        kernel.setExplicit(true);
+	        kernel.setArray(targetArray);
+	        kernel.put(targetArray);
+	        kernel.execute(range);
+	        kernel.get(targetArray);
+	        assertTrue(validate());
+        } finally {
+        	kernel.dispose();
+        }
+    }
+
+    @Test
+    public void testBarrier2JTP() {
+    	SIZE = 256;
+    	KernelManager.setKernelManager(new JTPKernelManager());
+        Device device = KernelManager.instance().bestDevice();
+        System.out.println("Executing on device: " + device.getShortDescription());
+        assumeTrue (device != null && device instanceof JavaDevice);
+
+        final Barrrier2Kernel kernel = new Barrrier2Kernel(SIZE);
+        try {
+	        final Range range = device.createRange(SIZE, SIZE);
+	        targetArray = initInputArray();
+	        kernel.setExplicit(false);
+	        kernel.setArray(targetArray);
+	        kernel.execute(range);
+	        assertTrue(validate());
+        } finally {
+        	kernel.dispose();
+        }
+    }
+
+    private int[] initInputArray() {
+    	int[] inputArray = new int[SIZE];
+    	for (int i = 0; i < SIZE; i++) {
+    		inputArray[i] = i;
+    	}
+    	return inputArray;
+    }
+    
+    private boolean validate() {
+    	int[] inputArray = initInputArray();
+        int[] expected = new int[SIZE];
+        for (int threadId = 0; threadId < SIZE; threadId++) {
+        	final int targetId = (SIZE - 1) - ((threadId + SIZE/2) % SIZE);
+        	expected[targetId] += inputArray[threadId];
+            for (int i = 0; i < SIZE; i++) {
+            	expected[threadId] += i;
+            }
+        }
+
+        int[] temp = expected;
+    	expected = new int[SIZE];
+        for (int threadId = 0; threadId < SIZE; threadId++) {
+        	int targetId = ((threadId + SIZE/2) % SIZE);
+        	expected[targetId] = temp[threadId];
+        }
+
+        for (int threadId = 0; threadId < SIZE; threadId++) {
+	    	if (threadId < SIZE/2) {
+	    		expected[threadId] += expected[(SIZE-1) - threadId];
+	    	}
+        }
+
+        assertArrayEquals("targetArray", expected, targetArray);
+        
+        return true;
+    }
+
+    private static class Barrrier1Kernel extends Kernel {
+    	private final int SIZE;
+        private int[] resultArray;
+        
+        @Local
+        private int[] myArray;
+        
+        private Barrrier1Kernel(int size) {
+        	this.SIZE = size;
+        	myArray = new int[size];
+        }
+        
+        @NoCL
+        public void setArray(int[] target) {
+            resultArray = target;
+        }
+
+        private void doInitialCopy(@Local int[] target, int[] source, int id) {
+        	int targetId = (SIZE - 1) - ((id + SIZE/2) % SIZE);
+        	target[targetId] = source[id];
+        }
+        
+        private void doComputation1(@Local int[] arr, int id) {
+            for (int i = 0; i < SIZE; i++) {
+                arr[id] += i;
+            }
+        }
+        
+        @Override
+        public void run() {
+            int id = getLocalId();                
+                        
+            doInitialCopy(myArray, resultArray, id);
+            localBarrier();
+            doComputation1(myArray, id);
+            int targetId = ((id + SIZE/2) % SIZE);
+            resultArray[targetId] = myArray[id];
+            globalBarrier();
+            if (id < SIZE/2) {
+            	resultArray[id] += resultArray[(SIZE - 1) - id];
+            }
+        }
+    }
+    
+    private static class Barrrier2Kernel extends Kernel {
+    	private final int SIZE;
+        private int[] resultArray;
+        
+        @Local
+        private int[] myArray;
+        
+        private Barrrier2Kernel(int size) {
+        	this.SIZE = size;
+        	myArray = new int[size];
+        }
+        
+        @NoCL
+        public void setArray(int[] target) {
+            resultArray = target;
+        }
+
+        private void doInitialCopy(@Local int[] target, int[] source, int id) {
+        	int targetId = (SIZE - 1) - ((id + SIZE/2) % SIZE);
+        	target[targetId] = source[id];
+        }
+        
+        private void doComputation1(@Local int[] arr, int id) {
+            for (int i = 0; i < SIZE; i++) {
+                arr[id] += i;
+            }
+        }
+        
+        @Override
+        public void run() {
+            int id = getLocalId();                
+                        
+            doInitialCopy(myArray, resultArray, id);
+            localGlobalBarrier();
+            doComputation1(myArray, id);
+            int targetId = ((id + SIZE/2) % SIZE);
+            resultArray[targetId] = myArray[id];
+            localGlobalBarrier();
+            if (id < SIZE/2) {
+            	resultArray[id] += resultArray[(SIZE - 1) - id];
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This PR will add full support for OpenCL 1.2  barrier() by de-deprecating globalBarrier() and introducing new localGlobalBarrier() corresponding respectively to OpenCL barrier(CLK_GLOBAL_MEM_FENCE) and barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE).