### PR TITLE
Update: Changed KernelManager for easy class extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Aparapi Changelog
 
 ## 1.7.1
+* Updated KernelManager to facilitate class extensions having constructors with non static parameters
 
 ## 1.7.0
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,3 +48,4 @@ Below are some of the specific details of various contributions.
 * Luis Mendes submited PR for issue #84 - Fully support OpenCL 1.2 barrier() - localBarrier(),  globalBarrier() and localGlobalBarrier()
 * Luis Mendes with suggestions by Automenta submited PR for issue #62 and implemented new thread-safe API for Kernel profiling
 * Luis Mendes submited PR for issue #101 - Possible deadlock in JTP mode
+* Luis Mendes submited PR to facilitate KernelManager class extension with non-static parameters in constructors

--- a/src/main/java/com/aparapi/internal/kernel/KernelManager.java
+++ b/src/main/java/com/aparapi/internal/kernel/KernelManager.java
@@ -43,9 +43,18 @@ public class KernelManager {
    private KernelPreferences defaultPreferences;
 
    protected KernelManager() {
-      defaultPreferences = createDefaultPreferences();
+      setup();
    }
 
+   /**
+    * Default KernelManager initialization.<br/>
+    * Convenience method for being overriden to an empty implementation, so that derived 
+    * KernelManager classes can provide non static parameters to their constructors.
+    */
+   protected void setup() {
+	   defaultPreferences = createDefaultPreferences(); 
+   }
+   
    public static KernelManager instance() {
       return INSTANCE;
    }


### PR DESCRIPTION
Previous KernelManager implementation defined a default initialization in it constructor which called a very likely method for being overriden, namely createDefaultPreferences().
This was causing difficulties when extending KernelManager with another class that intended to redefine createDefaultPreferences() method based on non-static values passed through the redefined constructor of the derived class.
What happens is that upon calling the derived class constructor it would call the super class default constructor which would call the overriden createDefaultPreferences() method even before the non-static class fields having been initialized from the new class constructor parameters. This could potential cause exceptions, but would also make createDefaultPreferences() being called before time.