### PR TITLE
Update: Enable kernel profiling and execution simultaneously on multiple devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0
 * Updated KernelManager to facilitate class extensions having constructors with non static parameters
+* Enable kernel profiling and execution simultaneously on multiple devices (multiple threads calling same kernel class on multiple devices)
 
 ## 1.7.0
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,3 +49,4 @@ Below are some of the specific details of various contributions.
 * Luis Mendes with suggestions by Automenta submited PR for issue #62 and implemented new thread-safe API for Kernel profiling
 * Luis Mendes submited PR for issue #101 - Possible deadlock in JTP mode
 * Luis Mendes submited PR to facilitate KernelManager class extension with non-static parameters in constructors
+* Luis Mendes submited PR to Enable kernel profiling and execution simultaneously on multiple devices

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>com.aparapi</groupId>
             <artifactId>aparapi-jni</artifactId>
-            <version>1.1.2</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -137,6 +137,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                	<skipTests>true</skipTests>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,9 +137,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                	<skipTests>true</skipTests>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/src/main/java/com/aparapi/device/Device.java
+++ b/src/main/java/com/aparapi/device/Device.java
@@ -18,7 +18,7 @@ package com.aparapi.device;
 import com.aparapi.*;
 import com.aparapi.internal.kernel.*;
 
-public abstract class Device{
+public abstract class Device implements Comparable<Device> {
 
    public static enum TYPE {
       UNKNOWN(Integer.MAX_VALUE),
@@ -178,5 +178,21 @@ public abstract class Device{
    @Override
    public int hashCode() {
       return Long.valueOf(getDeviceId()).hashCode();
+   }
+   
+   public int compareTo(Device other) {
+	   if (type.rank < other.type.rank) {
+		   return -1;
+	   } else if (type.rank > other.type.rank) {
+		   return 1;
+	   }
+	   
+	   if (getDeviceId() < other.getDeviceId()) {
+		   return -1;
+	   } else if (getDeviceId() > other.getDeviceId()) {
+		   return 1;
+	   }
+	   
+	   return 0;
    }
 }

--- a/src/main/java/com/aparapi/device/JavaDevice.java
+++ b/src/main/java/com/aparapi/device/JavaDevice.java
@@ -15,7 +15,7 @@
  */
 package com.aparapi.device;
 
-public class JavaDevice extends Device {
+public class JavaDevice extends Device implements Comparable<Device> {
 
    public static final JavaDevice THREAD_POOL = new JavaDevice(TYPE.JTP, "Java Thread Pool", -3);
    public static final JavaDevice ALTERNATIVE_ALGORITHM = new JavaDevice(TYPE.ALT, "Java Alternative Algorithm", -2);

--- a/src/main/java/com/aparapi/device/OpenCLDevice.java
+++ b/src/main/java/com/aparapi/device/OpenCLDevice.java
@@ -45,7 +45,7 @@ import com.aparapi.opencl.OpenCL.Local;
 import com.aparapi.opencl.OpenCL.Resource;
 import com.aparapi.opencl.OpenCL.Source;
 
-public class OpenCLDevice extends Device{
+public class OpenCLDevice extends Device implements Comparable<Device> {
 
    private final OpenCLPlatform platform;
 

--- a/src/main/java/com/aparapi/internal/kernel/KernelManager.java
+++ b/src/main/java/com/aparapi/internal/kernel/KernelManager.java
@@ -48,7 +48,7 @@ public class KernelManager {
 
    /**
     * Default KernelManager initialization.<br/>
-    * Convenience method for being overriden to an empty implementation, so that derived 
+    * Convenience method for being overridden to an empty implementation, so that derived 
     * KernelManager classes can provide non static parameters to their constructors.
     */
    protected void setup() {

--- a/src/main/java/com/aparapi/internal/kernel/KernelPreferences.java
+++ b/src/main/java/com/aparapi/internal/kernel/KernelPreferences.java
@@ -84,10 +84,12 @@ public class KernelPreferences {
    }
 
    private void maybeSetUpDefaultPreferredDevices() {
-	   preferredDevices.compareAndSet(null, new LinkedList<>(manager.getDefaultPreferences().getPreferredDevices(null)));
+	   if (preferredDevices.get() == null) {
+		   preferredDevices.compareAndSet(null, new LinkedList<>(manager.getDefaultPreferences().getPreferredDevices(null)));
+	   }
    }
 
-   public List<Device> getFailedDevices() {
+   public synchronized List<Device> getFailedDevices() {
       return new ArrayList<>(failedDevices);
    }
 }

--- a/src/main/java/com/aparapi/internal/kernel/KernelPreferences.java
+++ b/src/main/java/com/aparapi/internal/kernel/KernelPreferences.java
@@ -19,11 +19,15 @@ import com.aparapi.*;
 import com.aparapi.device.*;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 
+/**
+ * Thread safe class holding the kernel preferences for a given kernel class.
+ */
 public class KernelPreferences {
    private final Class<? extends Kernel> kernelClass;
    private final KernelManager manager;
-   private volatile LinkedList<Device> preferredDevices = null;
+   private final AtomicReference<LinkedList<Device>> preferredDevices = new AtomicReference<>(null);
    private final LinkedHashSet<Device> failedDevices = new LinkedHashSet<>();
 
    public KernelPreferences(KernelManager manager, Class<? extends Kernel> kernelClass) {
@@ -39,14 +43,16 @@ public class KernelPreferences {
    public List<Device> getPreferredDevices(Kernel kernel) {
       maybeSetUpDefaultPreferredDevices();
 
-      if (kernel == null) {
-         return Collections.unmodifiableList(preferredDevices);
-      }
-      List<Device> localPreferredDevices = new ArrayList<>();
       ArrayList<Device> copy;
-      synchronized (preferredDevices) {
-         copy = new ArrayList(preferredDevices);
+      synchronized (this) {
+         copy = new ArrayList<>(preferredDevices.get());
       }
+
+      if (kernel == null) {
+         return Collections.unmodifiableList(copy);
+      }
+      
+      List<Device> localPreferredDevices = new ArrayList<>();
       for (Device device : copy) {
          if (kernel.isAllowDevice(device)) {
             localPreferredDevices.add(device);
@@ -56,12 +62,12 @@ public class KernelPreferences {
    }
 
    synchronized void setPreferredDevices(LinkedHashSet<Device> _preferredDevices) {
-      if (preferredDevices != null) {
-         preferredDevices.clear();
-         preferredDevices.addAll(_preferredDevices);
+      if (preferredDevices.get() != null) {
+         preferredDevices.get().clear();
+         preferredDevices.get().addAll(_preferredDevices);
       }
       else {
-         preferredDevices = new LinkedList<>(_preferredDevices);
+         preferredDevices.set(new LinkedList<>(_preferredDevices));
       }
       failedDevices.clear();
    }
@@ -72,19 +78,13 @@ public class KernelPreferences {
    }
 
    synchronized void markPreferredDeviceFailed() {
-      if (preferredDevices.size() > 0) {
-         failedDevices.add(preferredDevices.remove(0));
+      if (preferredDevices.get().size() > 0) {
+         failedDevices.add(preferredDevices.get().remove(0));
       }
    }
 
    private void maybeSetUpDefaultPreferredDevices() {
-      if (preferredDevices == null) {
-         synchronized (this) {
-            if (preferredDevices == null) {
-               preferredDevices = new LinkedList<>(manager.getDefaultPreferences().getPreferredDevices(null));
-            }
-         }
-      }
+	   preferredDevices.compareAndSet(null, new LinkedList<>(manager.getDefaultPreferences().getPreferredDevices(null)));
    }
 
    public List<Device> getFailedDevices() {

--- a/src/main/java/com/aparapi/internal/kernel/KernelProfile.java
+++ b/src/main/java/com/aparapi/internal/kernel/KernelProfile.java
@@ -75,9 +75,12 @@ public class KernelProfile {
     */
    void onStart(Device device) {
 	  KernelDeviceProfile currentDeviceProfile = deviceProfiles.get(device);
-      if (currentDeviceProfile == null) {
+      if (currentDeviceProfile == null) {    	 
          currentDeviceProfile = new KernelDeviceProfile(this, kernelClass, device);
-         deviceProfiles.put(device, currentDeviceProfile);
+         KernelDeviceProfile existingProfile = deviceProfiles.putIfAbsent(device, currentDeviceProfile);
+         if (existingProfile != null) {
+        	 currentDeviceProfile = existingProfile;
+         }
       }
       
       currentDeviceProfile.onEvent(ProfilingEvent.START);

--- a/src/main/java/com/aparapi/internal/kernel/KernelProfile.java
+++ b/src/main/java/com/aparapi/internal/kernel/KernelProfile.java
@@ -19,23 +19,22 @@ import com.aparapi.*;
 import com.aparapi.device.*;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.*;
 
 /**
- * Collects profiling information per kernel class per device. Not thread safe, it is necessary for client code to correctly synchronize on
- * objects of this class.
+ * Collects profiling information per kernel class per device.
  */
 public class KernelProfile {
 
    public static final double MILLION = 1000000d;
    private static Logger logger = Logger.getLogger(Config.getLoggerName());
    private final Class<? extends Kernel> kernelClass;
-   private LinkedHashMap<Device, KernelDeviceProfile> deviceProfiles = new LinkedHashMap<>();
-   private Device currentDevice;
-   private Device lastDevice;
-   private KernelDeviceProfile currentDeviceProfile;
+   private ConcurrentSkipListMap<Device, KernelDeviceProfile> deviceProfiles = new ConcurrentSkipListMap<>();
+   private final AtomicReference<Device> currentDevice = new AtomicReference<Device>(null);
    private IProfileReportObserver observer;
-
+   
    public KernelProfile(Class<? extends Kernel> _kernelClass) {
       kernelClass = _kernelClass;
    }
@@ -60,24 +59,44 @@ public class KernelProfile {
       }
    }
 
+   /**
+    * Retrieves the last device profile that was updated by the last thread that made 
+    * a profiling information update, when executing this kernel on the specified device.
+    * @return the device profile 
+    */
    public KernelDeviceProfile getLastDeviceProfile() {
-      return deviceProfiles.get(currentDevice);
+      return deviceProfiles.get(currentDevice.get());
    }
 
+   /**
+    * Starts a profiling information gathering sequence for the current thread invoking this method
+    * regarding the specified execution device.
+    * @param device
+    */
    void onStart(Device device) {
-      synchronized (deviceProfiles) {
-         currentDeviceProfile = deviceProfiles.get(device);
-         if (currentDeviceProfile == null) {
-            currentDeviceProfile = new KernelDeviceProfile(this, kernelClass, device);
-            deviceProfiles.put(device, currentDeviceProfile);
-         }
+	  KernelDeviceProfile currentDeviceProfile = deviceProfiles.get(device);
+      if (currentDeviceProfile == null) {
+         currentDeviceProfile = new KernelDeviceProfile(this, kernelClass, device);
+         deviceProfiles.put(device, currentDeviceProfile);
       }
       
       currentDeviceProfile.onEvent(ProfilingEvent.START);
-      currentDevice = device;
+      currentDevice.set(device);
    }
 
-   void onEvent(ProfilingEvent event) {
+   /**
+    * Updates the profiling information for the current thread invoking this method regarding
+    * the specified execution device.
+    * 
+    * @param device the device where the kernel is/was executed
+    * @param event the event for which the profiling information is being updated
+    */
+   void onEvent(Device device, ProfilingEvent event) {
+	  if (event == null) {
+		  logger.log(Level.WARNING, "Discarding profiling event " + event + " for null device, for Kernel class: " + kernelClass.getName());
+		  return;
+	  }
+	  final KernelDeviceProfile deviceProfile = deviceProfiles.get(device);
       switch (event) {
          case CLASS_MODEL_BUILT: // fallthrough
          case OPENCL_GENERATED:  // fallthrough
@@ -86,10 +105,10 @@ public class KernelProfile {
          case PREPARE_EXECUTE:   // fallthrough
          case EXECUTED:          // fallthrough
          {
-            if (currentDeviceProfile == null) {
+            if (deviceProfile == null) {
                logger.log(Level.SEVERE, "Error in KernelProfile, no currentDevice (synchronization error?");
             }
-            currentDeviceProfile.onEvent(event);
+            deviceProfile.onEvent(event);
             break;
          }
          case START:
@@ -97,16 +116,6 @@ public class KernelProfile {
          default:
             throw new IllegalArgumentException("Unhandled event " + event);
       }
-   }
-
-   void onFinishedExecution() {
-      reset();
-   }
-
-   private void reset() {
-      lastDevice = currentDevice;
-      currentDevice = null;
-      currentDeviceProfile = null;
    }
 
    public Collection<Device> getDevices() {

--- a/src/main/java/com/aparapi/internal/kernel/KernelRunner.java
+++ b/src/main/java/com/aparapi/internal/kernel/KernelRunner.java
@@ -1307,6 +1307,8 @@ public class KernelRunner extends KernelRunnerJNI{
             logger.warning("Device failed for " + kernel + ": " + _exception.getMessage());
          }
 
+         //This method is synchronized thus ensuring thread safety on concurrent executions of the same kernel class,
+         //since preferences is shared between such threads.
          preferences.markPreferredDeviceFailed();
 
 //         Device nextDevice = preferences.getPreferredDevice(kernel);
@@ -1337,11 +1339,7 @@ public class KernelRunner extends KernelRunnerJNI{
          boolean legacyExecutionMode = kernel.getExecutionMode() != Kernel.EXECUTION_MODE.AUTO;
 
          ExecutionSettings settings = new ExecutionSettings(preferences, profile, _entrypoint, _range, _passes, legacyExecutionMode);
-         // Two Kernels of the same class share the same KernelPreferences object, and since failure (fallback) generally mutates
-         // the preferences object, we must lock it. Note this prevents two Kernels of the same class executing simultaneously.
-         synchronized (preferences) {
-            return executeInternalOuter(settings);
-         }
+         return executeInternalOuter(settings);
       } finally {
          executing = false;
          clearCancelMultiPass();


### PR DESCRIPTION
(multiple threads calling same kernel class on multiple devices)

This update is logically composed of two parts:
Part 1 -  Enable KernelProfile to handle profiling events originated simultaneously from different devices by concurrent threads executing the same kernel. This was the first set of commits and avoids seeing SEVERE log messages under such situations, while also ensuring correct profiling information when concurrently using multiple devices. 
The affected classes were KernelRunner and KernelProfile.
Part 2 - Enable concurrent execution on multiple devices by removing the synchronized(preferences) from KernelRunner.execute(...) which is a bit overkill for possible rare modifications of preferences instance and occasional method calls. Additional thread safety is ensured by making KernelPreferences inherently thread safe.