### PR TITLE
Update tests ProfileReportBackwardsCompatTest timeouts #113 and introduce test for #78

### DIFF
--- a/src/test/java/com/aparapi/runtime/NegativeIntegerTest.java
+++ b/src/test/java/com/aparapi/runtime/NegativeIntegerTest.java
@@ -33,7 +33,7 @@ import com.aparapi.device.OpenCLDevice;
 import com.aparapi.internal.kernel.KernelManager;
 
 /**
- * Originally created for testing issue #81
+ * Originally created for testing issue #78
  *
  */
 public class NegativeIntegerTest

--- a/src/test/java/com/aparapi/runtime/NegativeIntegerTest.java
+++ b/src/test/java/com/aparapi/runtime/NegativeIntegerTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2016 - 2017 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aparapi.runtime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.aparapi.Kernel;
+import com.aparapi.Range;
+import com.aparapi.device.Device;
+import com.aparapi.device.OpenCLDevice;
+import com.aparapi.internal.kernel.KernelManager;
+
+/**
+ * Originally created for testing issue #81
+ *
+ */
+public class NegativeIntegerTest
+{
+	
+    private static OpenCLDevice openCLDevice = null;
+
+    private class CLKernelManager extends KernelManager {
+    	@Override
+    	protected List<Device.TYPE> getPreferredDeviceTypes() {
+    		return Arrays.asList(Device.TYPE.ACC, Device.TYPE.GPU, Device.TYPE.CPU);
+    	}
+    }
+    
+    @Before
+    public void setUpBeforeClass() throws Exception {
+    	KernelManager.setKernelManager(new CLKernelManager());
+        Device device = KernelManager.instance().bestDevice();
+        if (device == null || !(device instanceof OpenCLDevice)) {
+        	System.out.println("!!!No OpenCLDevice available for running the integration test");
+        }
+        assumeTrue (device != null && device instanceof OpenCLDevice);
+        openCLDevice = (OpenCLDevice) device;
+    }
+    
+    @Ignore("Test currently failing")
+    @Test
+    public void negativeIntegerTestPass()
+    {
+    	final Device device = openCLDevice;
+        final int SIZE = 1;
+        final int[] RESULT = new int[2];
+        Kernel kernel = new Kernel()
+        {
+             @Override
+            public void run()
+            {
+                RESULT[0] = -800;
+            }
+        };
+        kernel.execute(Range.create(device, SIZE, SIZE));
+        assertEquals("Result doesn't match", -800, RESULT[0]);
+    }
+}

--- a/src/test/java/com/aparapi/runtime/ProfileReportBackwardsCompatTest.java
+++ b/src/test/java/com/aparapi/runtime/ProfileReportBackwardsCompatTest.java
@@ -139,7 +139,7 @@ public class ProfileReportBackwardsCompatTest {
     		assertEquals("Aparapi Accumulated execution time doesn't match", accumulatedExecutionTime, kernel.getAccumulatedExecutionTime(), 1e-10);
     		assertEquals("Aparapi last execution time doesn't match last report", lastExecutionTime, report.getExecutionTime(), 1e-10);
     		assertEquals("Aparapi last conversion time doesn't match last report", lastConversionTime, report.getConversionTime(), 1e-10);
-    		assertEquals("Test estimated accumulated time doesn't match within 100ms window", runTime, accumulatedExecutionTime, 100);
+    		assertEquals("Test estimated accumulated time doesn't match within 500ms window", runTime, accumulatedExecutionTime, 500);
     		assertTrue(validateBasic1Kernel(inputArray, outputArray));
     	} finally {
     		kernel.dispose();
@@ -230,7 +230,7 @@ public class ProfileReportBackwardsCompatTest {
     		assertEquals("Aparapi Accumulated execution time doesn't match", results[0].accumulatedExecutionTime, kernel1.getAccumulatedExecutionTime(), 1e-10);
     		assertEquals("Aparapi last execution time doesn't match last report", results[0].lastExecutionTime, report.getExecutionTime(), 1e-10);
     		assertEquals("Aparapi last conversion time doesn't match last report", results[0].lastConversionTime, report.getConversionTime(), 1e-10);
-    		assertEquals("Test estimated accumulated time doesn't match within 100ms window", results[0].runTime, results[0].accumulatedExecutionTime, 100);
+    		assertEquals("Test estimated accumulated time doesn't match within 300ms window", results[0].runTime, results[0].accumulatedExecutionTime, 300);
     		assertTrue(validateBasic1Kernel(inputArray, results[0].outputArray));
     		
     		//Validate kernel2 reports
@@ -240,7 +240,7 @@ public class ProfileReportBackwardsCompatTest {
     		assertEquals("Aparapi Accumulated execution time doesn't match", results[1].accumulatedExecutionTime, kernel2.getAccumulatedExecutionTime(), 1e-10);
     		assertEquals("Aparapi last execution time doesn't match last report", results[1].lastExecutionTime, report.getExecutionTime(), 1e-10);
     		assertEquals("Aparapi last conversion time doesn't match last report", results[1].lastConversionTime, report.getConversionTime(), 1e-10);
-    		assertEquals("Test estimated accumulated time doesn't match within 100ms window", results[1].runTime, results[1].accumulatedExecutionTime, 100);
+    		assertEquals("Test estimated accumulated time doesn't match within 300ms window", results[1].runTime, results[1].accumulatedExecutionTime, 300);
     		assertTrue(validateBasic2Kernel(inputArray, results[1].outputArray));
     	} finally {
     		kernel1.dispose();


### PR DESCRIPTION
- ProfileReportBackwardsCompatTest were giving timeouts #113 on slow machine so the timeout was increased.

- Created a new integration test that exhibits issue #78 - "Negative integer Java constant -800 turns into opencl constant 64736" and set the test to ignore.