### PR TITLE
Fix: Signed integer constants were interpreted as unsigned for instruction SIPUSH (refs #78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Updated KernelManager to facilitate class extensions having constructors with non static parameters
 * Enable kernel profiling and execution simultaneously on multiple devices (multiple threads calling same kernel class on multiple devices)
 * Fixed JVM crash with multi-dimensional arrays in Local memory (2D and 3D local arrays are now supported)
+* Fixed: Signed integer constants were being interpreted as unsigned values in instruction SIPUSH
 
 ## 1.7.0
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -50,3 +50,4 @@ Below are some of the specific details of various contributions.
 * Luis Mendes submited PR for issue #101 - Possible deadlock in JTP mode
 * Luis Mendes submited PR to facilitate KernelManager class extension with non-static parameters in constructors
 * Luis Mendes submited PR to Enable kernel profiling and execution simultaneously on multiple devices
+* Luis Mendes submited PR to fix issue #78 - Signed integer constants were interpreted as unsigned values for instruction SIPUSH

--- a/src/main/java/com/aparapi/internal/instruction/InstructionSet.java
+++ b/src/main/java/com/aparapi/internal/instruction/InstructionSet.java
@@ -3507,7 +3507,7 @@ public class InstructionSet{
    public static class I_SIPUSH extends ImmediateConstant<Integer>{
       public I_SIPUSH(MethodModel _methodPoolEntry, ByteReader _byteReader, boolean _wide) {
          super(_methodPoolEntry, ByteCode.SIPUSH, _byteReader, _wide);
-         value = _byteReader.u2();
+         value = _byteReader.s2();
       }
 
       @Override public String getDescription() {

--- a/src/test/java/com/aparapi/runtime/NegativeIntegerTest.java
+++ b/src/test/java/com/aparapi/runtime/NegativeIntegerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2017 Syncleus, Inc.
+ * Copyright (c) 2016 - 2018 Syncleus, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.aparapi.runtime;
 
 import static org.junit.Assert.assertEquals;
@@ -59,7 +58,6 @@ public class NegativeIntegerTest
         openCLDevice = (OpenCLDevice) device;
     }
     
-    @Ignore("Test currently failing")
     @Test
     public void negativeIntegerTestPass()
     {


### PR DESCRIPTION
Java bytecode instruction SIPUSH pushes a signed 16-bit immediate value, not unsigned 16-bit value.
https://cs.au.dk/~mis/dOvs/jvmspec/ref-sipush.html