### PR TITLE
Fix: Fix kernel management inconsistencies regarding preferred device…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.10.0
 
 * If statements with empty blocks and comparisons outside of if or while statements now compile and run on the GPU.
+* Fix kernel management inconsistencies regarding preferred devices management 
 
 ## 1.9.0
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,3 +52,4 @@ Below are some of the specific details of various contributions.
 * Luis Mendes submited PR to Enable kernel profiling and execution simultaneously on multiple devices
 * Luis Mendes submited PR to fix issue #78 - Signed integer constants were interpreted as unsigned values for instruction SIPUSH
 * Luis Mendes submited PR to Support for OpenCLDevice configurator/configure API
+* Luis mendes submited PR to fix kernel management inconsistencies regarding preferred devices management

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                	<forkCount>4</forkCount>
+                	<reuseForks>false</reuseForks>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/src/main/java/com/aparapi/internal/kernel/KernelManager.java
+++ b/src/main/java/com/aparapi/internal/kernel/KernelManager.java
@@ -36,7 +36,7 @@ import com.aparapi.internal.util.Reflection;
 public class KernelManager {
 
    private static KernelManager INSTANCE = new KernelManager();
-   private LinkedHashMap<Integer, PreferencesWrapper> preferences = new LinkedHashMap<>();
+   private LinkedHashMap<Class<? extends Kernel>, PreferencesWrapper> preferences = new LinkedHashMap<>();
    private LinkedHashMap<Class<? extends Kernel>, KernelProfile> profiles = new LinkedHashMap<>();
    private LinkedHashMap<Class<? extends Kernel>, Kernel> sharedInstances = new LinkedHashMap<>();
 
@@ -157,13 +157,13 @@ public class KernelManager {
 
    public KernelPreferences getPreferences(Kernel kernel) {
       synchronized (preferences) {
-         PreferencesWrapper wrapper = preferences.get(kernel.hashCode());
+         PreferencesWrapper wrapper = preferences.get(kernel.getClass());
          KernelPreferences kernelPreferences;
          if (wrapper == null) {
             kernelPreferences = new KernelPreferences(this, kernel.getClass());
-            preferences.put(kernel.hashCode(), new PreferencesWrapper(kernel.getClass(), kernelPreferences));
+            preferences.put(kernel.getClass(), new PreferencesWrapper(kernel.getClass(), kernelPreferences));
          }else{
-           kernelPreferences = preferences.get(kernel.hashCode()).getPreferences();
+           kernelPreferences = preferences.get(kernel.getClass()).getPreferences();
          }
          return kernelPreferences;
       }

--- a/src/main/java/com/aparapi/internal/kernel/KernelPreferences.java
+++ b/src/main/java/com/aparapi/internal/kernel/KernelPreferences.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class KernelPreferences {
    private final Class<? extends Kernel> kernelClass;
    private final KernelManager manager;
-   private final AtomicReference<LinkedList<Device>> preferredDevices = new AtomicReference<>(null);
+   private final AtomicReference<LinkedHashSet<Device>> preferredDevices = new AtomicReference<>(null);
    private final LinkedHashSet<Device> failedDevices = new LinkedHashSet<>();
 
    public KernelPreferences(KernelManager manager, Class<? extends Kernel> kernelClass) {
@@ -60,6 +60,24 @@ public class KernelPreferences {
       }
       return Collections.unmodifiableList(localPreferredDevices);
    }
+   
+   /**
+    * Validates if the specified devices is among the preferred devices for executing the kernel associated with the current
+    * kernel preferences.
+    * @param device the device to be tested
+    * @return <ul><li>true, if specified device is among the preferred devices</li>
+    *             <li>false, otherwise</li></ul>
+    */
+   public boolean isDeviceAmongPreferredDevices(Device device) {
+	   maybeSetUpDefaultPreferredDevices();
+	   
+	   boolean result = false;
+	   synchronized (this) {
+		   result = preferredDevices.get().contains(device);
+	   }
+	   
+	   return result;
+   }
 
    synchronized void setPreferredDevices(LinkedHashSet<Device> _preferredDevices) {
       if (preferredDevices.get() != null) {
@@ -67,7 +85,7 @@ public class KernelPreferences {
          preferredDevices.get().addAll(_preferredDevices);
       }
       else {
-         preferredDevices.set(new LinkedList<>(_preferredDevices));
+         preferredDevices.set(new LinkedHashSet<>(_preferredDevices));
       }
       failedDevices.clear();
    }
@@ -78,14 +96,23 @@ public class KernelPreferences {
    }
 
    synchronized void markPreferredDeviceFailed() {
-      if (preferredDevices.get().size() > 0) {
-         failedDevices.add(preferredDevices.get().remove(0));
+	  LinkedHashSet<Device> devices = preferredDevices.get();
+      if (devices.size() > 0) {
+    	 Device device = devices.iterator().next();
+    	 preferredDevices.get().remove(device);
+         failedDevices.add(device);
       }
    }
+   
+   synchronized void markDeviceFailed(Device device) {
+	   preferredDevices.get().remove(device);
+       failedDevices.add(device);
+   }
+
 
    private void maybeSetUpDefaultPreferredDevices() {
 	   if (preferredDevices.get() == null) {
-		   preferredDevices.compareAndSet(null, new LinkedList<>(manager.getDefaultPreferences().getPreferredDevices(null)));
+		   preferredDevices.compareAndSet(null, new LinkedHashSet<>(manager.getDefaultPreferences().getPreferredDevices(null)));
 	   }
    }
 

--- a/src/main/java/com/aparapi/internal/kernel/KernelRunner.java
+++ b/src/main/java/com/aparapi/internal/kernel/KernelRunner.java
@@ -1309,7 +1309,7 @@ public class KernelRunner extends KernelRunnerJNI{
 
          //This method is synchronized thus ensuring thread safety on concurrent executions of the same kernel class,
          //since preferences is shared between such threads.
-         preferences.markPreferredDeviceFailed();
+         preferences.markDeviceFailed(device);
 
 //         Device nextDevice = preferences.getPreferredDevice(kernel);
 //
@@ -1750,7 +1750,7 @@ public class KernelRunner extends KernelRunnerJNI{
                return false;
          }
       } else {
-         return (device == kernel.getTargetDevice());
+         return KernelManager.instance().getPreferences(kernel).isDeviceAmongPreferredDevices(device);
       }
    }
 


### PR DESCRIPTION
…s management

Assuming invocation like:
Range range = device.createRange(...);
kernel.execute(range);

Fixes 4 issues...
Issue1 - If device instance is not the same device instance in 
              KernelPreferences.getPreferredDevice(Kernel kernel)
            the kernel wouldn't execute.

Issue2 - If device is not the first in the list of the KernelPreferences.preferredDevices then
             KernelPreferences.getPreferredDevice(Kernel kernel) will return another device
           the kernel wouldn't execute.

Issue3 - If boolean Kernel.isAllowedDevice(Device device) didn't allow the device that is returned by
             KernelPreferences.getPreferredDevice(Kernel kernel) but allowed another device(s) that are
             in the list of the KernelPreferences.preferredDevices 
           the kernel wouldn't execute.

Issue4 - KernelManager was storing the kernel preferences based on object hashCode() default implementation, which could result in collisions even with other kernel classes. It would also keep many kernel preferences, which make it difficult for client code to manage the preferences. In my opinion it is just over-engineering which complicates programming and code management with no added benefits. A KernelPreferences instance per Kernel class suffices. The user just specifies which devices are allowed for running a given kernel class, and then refines the selected device that actually executes the kernel with:
Range range = device.createRange(...);
kernel.execute(range);
