### PR TITLE
Update: Fix and Improve Java execution mode, avoiding deadlocks with …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * If statements with empty blocks and comparisons outside of if or while statements now compile and run on the GPU.
 * Fix kernel management inconsistencies regarding preferred devices management 
+* Fix Java execution mode with barriers to not deadlock when a thread dies or is interrupted (InterruptedException)
+* Fix Java execution mode to fail-fast when Kernel execution fails
+* Java execution mode now provides detailed backtraces of failed Kernel threads including passId, groupIds, globalIds and localIds
 
 ## 1.9.0
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -52,4 +52,7 @@ Below are some of the specific details of various contributions.
 * Luis Mendes submited PR to Enable kernel profiling and execution simultaneously on multiple devices
 * Luis Mendes submited PR to fix issue #78 - Signed integer constants were interpreted as unsigned values for instruction SIPUSH
 * Luis Mendes submited PR to Support for OpenCLDevice configurator/configure API
-* Luis mendes submited PR to fix kernel management inconsistencies regarding preferred devices management
+* Luis Mendes submited PR to fix kernel management inconsistencies regarding preferred devices management
+* Luis Mendes submited PR to Fix Java execution mode with barriers to not deadlock when a thread dies or is interrupted (InterruptedException)
+* Luis Mendes submited PR to Fix Java execution mode to fail-fast when Kernel execution fails
+* Luis Mendes submited PR to Java execution mode now provides detailed backtraces of failed Kernel threads including passId, groupIds, globalIds and localIds

--- a/src/main/java/com/aparapi/exception/AparapiBrokenBarrierException.java
+++ b/src/main/java/com/aparapi/exception/AparapiBrokenBarrierException.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016 - 2018 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.aparapi.exception;
+
+/**
+ * Exception is thrown when an Aparapi kernel is executing in Java mode, 
+ * and a barrier cannot be completed due to threads that die during its execution.
+ * 
+ * Aparapi ensures execution won't deadlock due to such an event, resulting in 
+ * fail-fast code, and allowing easy perception of the failure cause.
+ * 
+ * One such case is when an Aparapi kernel accesses outside a valid array position.
+ *    
+ * 
+ * @author CoreRasurae
+ */
+public class AparapiBrokenBarrierException extends RuntimeException {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1472616497910700885L;
+
+	public AparapiBrokenBarrierException(String message) {
+		super(message);
+	}
+
+	public AparapiBrokenBarrierException(Throwable cause) {
+		super(cause);
+	}
+
+	public AparapiBrokenBarrierException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public AparapiBrokenBarrierException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+}

--- a/src/main/java/com/aparapi/exception/AparapiKernelFailedException.java
+++ b/src/main/java/com/aparapi/exception/AparapiKernelFailedException.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016 - 2018 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.aparapi.exception;
+
+/**
+ * This exception is thrown when a Java kernel execution fails.
+ * 
+ * It is intended to convey information about the local and global Ids of the thread that failed, while
+ * avoiding from polluting the relevant stack trace.
+ * 
+ * One such example is when a Java kernel accesses outside an array due to an out of bounds index.
+ * 
+ * @author CoreRasurae
+ */
+public class AparapiKernelFailedException extends RuntimeException {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -7880680698955519049L;
+
+	public AparapiKernelFailedException(String message) {
+		super(message);
+	}
+
+	public AparapiKernelFailedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public AparapiKernelFailedException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+	
+	@Override
+	public synchronized Throwable fillInStackTrace() {
+	    //Suppress the stack trace of these exceptions
+	    return null;
+	}
+}

--- a/src/main/java/com/aparapi/internal/kernel/IKernelBarrier.java
+++ b/src/main/java/com/aparapi/internal/kernel/IKernelBarrier.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2016 - 2018 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.aparapi.internal.kernel;
+
+import java.util.concurrent.ForkJoinPool.ManagedBlocker;
+
+/**
+ * Provides the interface for Aparapi Kernel barriers.
+ * 
+ * @author CoreRasurae
+ */
+public interface IKernelBarrier extends ManagedBlocker {
+	/**
+	 * Cancels the barrier.
+	 * 
+	 * All threads that may be waiting for the barrier are released and barrier is permanently disabled.
+	 */
+	public void cancelBarrier();
+	
+	/**
+	 * Breaks the barrier.
+	 * 
+	 * All threads that may be waiting for the barrier are released and will throw {@link com.aparapi.exception.AparapiBrokenBarrierException}.
+	 * @param t the Throwable causing the barrier to break.
+	 */
+	public void breakBarrier(Throwable e);
+}


### PR DESCRIPTION
…barriers, fail-fast and provide detail information about the failed Kernel thread

This PR proposes the follwing fixes and updates:
* Fix Java execution mode with barriers to not deadlock when a thread dies or is interrupted (InterruptedException)
* Fix Java execution mode to fail-fast when Kernel execution fails
* Java execution mode now provides detailed backtraces of failed Kernel threads including passId, groupIds, globalIds and localIds
