### PR TITLE
Fix: Disable assertion in ProfileReportNewAPITest.multiThreadedSingle…

### DIFF
--- a/src/test/java/com/aparapi/runtime/ProfileReportNewAPITest.java
+++ b/src/test/java/com/aparapi/runtime/ProfileReportNewAPITest.java
@@ -337,7 +337,8 @@ public class ProfileReportNewAPITest {
         			results[i].accumulatedExecutionTime, state.accumulatedElapsedTime, 1e-10);
         	allThreadsAccumulatedTime += state.accumulatedElapsedTime;
         	assertTrue("Thread index " + i + " kernel computation doesn't match the expected", validateBasic1Kernel(inputArray, results[i].outputArray));
-        	assertEquals("Runtime is not within 600ms of the kernel estimated", results[i].runTime, state.accumulatedElapsedTime, 600);
+        	//FIXME Find a better way of determining kernel execution time
+        	//assertEquals("Runtime is not within 600ms of the kernel estimated", results[i].runTime, state.accumulatedElapsedTime, 600);
     	}
 
     	assertEquals("Overall kernel execution time doesn't match",


### PR DESCRIPTION
…KernelReportObserverTestHelper which is working unreliably, due to improper kernel execution time accounting