### PR TITLE
Jdk10/issue12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Aparapi Changelog
 
 ## v1.10.1
+* Fixed the header genaration for JDK8 and above.
 
 ## 1.10.0
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,6 +24,7 @@
 * Toon Baeyens <toon.baeyens@gmail.com>
 * Luis Mendes <luis.p.mendes@gmail.com>
 * Saurabh Rawat <saurabh.rawat90@gmail.com>
+* Sven Guenther <sven.guenther@gmail.com>
 
 # Details
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-h</arg>
+                        <arg>../include/</arg>
+                     </compilerArgs>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/src/main/java/com/aparapi/Config.java
+++ b/src/main/java/com/aparapi/Config.java
@@ -58,6 +58,8 @@ import com.aparapi.internal.tool.*;
 
 import java.util.logging.*;
 
+import java.lang.annotation.Native;
+
 /**
  * A central location for holding all runtime configurable properties as well as logging configuration.
  * 
@@ -151,6 +153,7 @@ public class Config extends ConfigJNI{
    public static final boolean enablePUTSTATIC = Boolean.getBoolean(propPkgName + ".enable.PUTSTATIC");
 
    // Allow static array accesses 
+   @Native
    public static final boolean enableGETSTATIC = true; //Boolean.getBoolean(propPkgName + ".enable.GETSTATIC");
 
    public static final boolean enableINVOKEINTERFACE = Boolean.getBoolean(propPkgName + ".enable.INVOKEINTERFACE");

--- a/src/main/java/com/aparapi/Kernel.java
+++ b/src/main/java/com/aparapi/Kernel.java
@@ -63,6 +63,7 @@ import com.aparapi.internal.opencl.OpenCLLoader;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Native;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -1946,6 +1947,7 @@ public abstract class Kernel implements Cloneable {
    }
 
     private static final double LOG_2_RECIPROCAL = 1.0D / Math.log(2.0D);
+    @Native
     private static final double PI_RECIPROCAL = 1.0D / Math.PI;
 
     @OpenCLMapping(mapTo = "acospi")

--- a/src/main/java/com/aparapi/Range.java
+++ b/src/main/java/com/aparapi/Range.java
@@ -19,6 +19,7 @@ import com.aparapi.device.*;
 import com.aparapi.internal.jni.*;
 
 import java.util.*;
+import java.lang.annotation.Native;
 
 /**
  * 
@@ -64,8 +65,10 @@ import java.util.*;
  */
 public class Range extends RangeJNI{
 
+   @Native
    public static final int THREADS_PER_CORE = 16;
 
+   @Native
    public static final int MAX_OPENCL_GROUP_SIZE = 256;
 
    public static final int MAX_GROUP_SIZE = Math.max(Runtime.getRuntime().availableProcessors() * THREADS_PER_CORE,

--- a/src/main/java/com/aparapi/internal/opencl/OpenCLArgDescriptor.java
+++ b/src/main/java/com/aparapi/internal/opencl/OpenCLArgDescriptor.java
@@ -18,36 +18,53 @@
  */
 package com.aparapi.internal.opencl;
 
+import java.lang.annotation.Native;
+
 public class OpenCLArgDescriptor{
 
+   @Native
    public final static int ARG_BYTE_BIT = 1 << 0x000;
 
+   @Native
    public final static int ARG_SHORT_BIT = 1 << 0x001;
 
+   @Native
    public final static int ARG_INT_BIT = 1 << 0x002;
 
+   @Native
    public final static int ARG_FLOAT_BIT = 1 << 0x003;
 
+   @Native
    public final static int ARG_LONG_BIT = 1 << 0x004;
 
+   @Native
    public final static int ARG_DOUBLE_BIT = 1 << 0x005;
 
+   @Native
    public final static int ARG_ARRAY_BIT = 1 << 0x006;
 
+   @Native
    public final static int ARG_PRIMITIVE_BIT = 1 << 0x007;
 
+   @Native
    public final static int ARG_GLOBAL_BIT = 1 << 0x008;
 
+   @Native
    public final static int ARG_LOCAL_BIT = 1 << 0x009;
 
+   @Native
    public final static int ARG_CONST_BIT = 1 << 0x00A;
 
+   @Native
    public final static int ARG_READONLY_BIT = 1 << 0x00B;
 
+   @Native
    public final static int ARG_WRITEONLY_BIT = 1 << 0x00C;
 
+   @Native
    public final static int ARG_READWRITE_BIT = 1 << 0x00D;
 
+   @Native
    public final static int ARG_ISARG_BIT = 1 << 0x00E;
 
    public OpenCLMem memVal;

--- a/src/main/java/com/aparapi/internal/opencl/OpenCLMem.java
+++ b/src/main/java/com/aparapi/internal/opencl/OpenCLMem.java
@@ -15,12 +15,18 @@
  */
 package com.aparapi.internal.opencl;
 
+import java.lang.annotation.Native;
+
+
 public class OpenCLMem{
 
+   @Native
    public final static int MEM_DIRTY_BIT = 1 << 0x00F;
 
+   @Native
    public final static int MEM_COPY_BIT = 1 << 0x010;
 
+   @Native
    public final static int MEM_ENQUEUED_BIT = 1 << 0x011;
 
    public long bits; // dirty, copy, enqueued


### PR DESCRIPTION
tldr: Remove the usage of javah to support JDK above 8.

With the JDK8 the javah command is deprecated and is removed in jdk9, the function is now supported by the javac command. But the source code needs the java native annotation. The Patch add the necessary annotations and enable the header generation by the compiler.