### PR TITLE
Make scala-library test scoped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>2.12.6</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This Scala dependency only seems to be used for testing.  As such, it probably does not need to be a fully-fledged dependency and it can be test scoped in the POM so that consumers of the Aparapi JAR don't need to have `scala-library`.

Ref : Make Scala optional #144