### PR TITLE
Mangle OpenCL reserved identifiers during code generation

### DIFF
--- a/src/main/java/com/aparapi/internal/writer/BlockWriter.java
+++ b/src/main/java/com/aparapi/internal/writer/BlockWriter.java
@@ -80,6 +80,31 @@ public abstract class BlockWriter{
 
    public final static String arrayDimMangleSuffix = "__javaArrayDimension";
 
+   private static final Set<String> openCLReservedIdentifiers = Collections.unmodifiableSet(new HashSet<String>(
+         Arrays.asList(
+               "__constant", "__global", "__kernel", "__local", "__private",
+               "char", "char2", "char3", "char4", "char8", "char16",
+               "constant", "double", "double2", "double3", "double4", "double8", "double16",
+               "event_t", "float", "float2", "float3", "float4", "float8", "float16",
+               "global", "half", "image1d_t", "image1d_array_t", "image1d_buffer_t",
+               "image2d_t", "image2d_array_t", "image3d_t", "int", "int2", "int3", "int4",
+               "int8", "int16", "kernel", "local", "long", "long2", "long3", "long4",
+               "long8", "long16", "private", "queue_t", "read_only", "read_write",
+               "reserve_id_t", "sampler_t", "short", "short2", "short3", "short4",
+               "short8", "short16", "uchar", "uchar2", "uchar3", "uchar4", "uchar8",
+               "uchar16", "uint", "uint2", "uint3", "uint4", "uint8", "uint16",
+               "ulong", "ulong2", "ulong3", "ulong4", "ulong8", "ulong16", "unsigned",
+               "ushort", "ushort2", "ushort3", "ushort4", "ushort8", "ushort16",
+               "void", "volatile", "write_only")));
+
+   protected String getOpenCLIdentifier(String identifier) {
+      if (openCLReservedIdentifiers.contains(identifier)) {
+         return "aparapi_" + identifier;
+      }
+
+      return identifier;
+   }
+
    public abstract void write(String _string);
 
    public void writeln(String _string) {
@@ -309,7 +334,7 @@ public abstract class BlockWriter{
       in();
       newLine();
       write("return this->");
-      write(accessorVariableFieldEntry.getNameAndTypeEntry().getNameUTF8Entry().getUTF8());
+      write(getOpenCLIdentifier(accessorVariableFieldEntry.getNameAndTypeEntry().getNameUTF8Entry().getUTF8()));
       write(";");
       out();
       newLine();
@@ -417,7 +442,7 @@ public abstract class BlockWriter{
              } else {
                  final String descriptor = localVariableInfo.getVariableDescriptor();
                  write(convertType(descriptor, true, true));
-                 write(localVariableInfo.getVariableName());
+                 write(getOpenCLIdentifier(localVariableInfo.getVariableName()));
              }
          } else {
              if (assignToLocalVariable.isDeclaration()) {
@@ -431,7 +456,7 @@ public abstract class BlockWriter{
              if (localVariableInfo == null) {
                  throw new CodeGenException("outOfScope" + _instruction.getThisPC() + " = ");
              } else {
-                 write(localVariableInfo.getVariableName() + " = ");
+                 write(getOpenCLIdentifier(localVariableInfo.getVariableName()) + " = ");
              }
          }
 
@@ -481,7 +506,7 @@ public abstract class BlockWriter{
 
             NameAndTypeEntry nameAndTypeEntry = ((AccessField) load).getConstantPoolFieldEntry().getNameAndTypeEntry();
             if (isMultiDimensionalArray(nameAndTypeEntry)) {
-               String arrayName = nameAndTypeEntry.getNameUTF8Entry().getUTF8();
+               String arrayName = getOpenCLIdentifier(nameAndTypeEntry.getNameUTF8Entry().getUTF8());
                write(" * this->" + arrayName + arrayDimMangleSuffix + dim);
             }
          }
@@ -506,7 +531,7 @@ public abstract class BlockWriter{
                writeThisRef();
             }
          }
-         write(accessField.getConstantPoolFieldEntry().getNameAndTypeEntry().getNameUTF8Entry().getUTF8());
+         write(getOpenCLIdentifier(accessField.getConstantPoolFieldEntry().getNameAndTypeEntry().getNameUTF8Entry().getUTF8()));
 
       } else if (_instruction instanceof I_ARRAYLENGTH) {
 
@@ -521,7 +546,7 @@ public abstract class BlockWriter{
             dim++;
          }
          NameAndTypeEntry nameAndTypeEntry = ((AccessInstanceField) load).getConstantPoolFieldEntry().getNameAndTypeEntry();
-         final String arrayName = nameAndTypeEntry.getNameUTF8Entry().getUTF8();
+         final String arrayName = getOpenCLIdentifier(nameAndTypeEntry.getNameUTF8Entry().getUTF8());
          String dimSuffix = isMultiDimensionalArray(nameAndTypeEntry) ? Integer.toString(dim) : "";
          write("this->" + arrayName + arrayLengthMangleSuffix + dimSuffix);
       } else if (_instruction instanceof AssignToField) {
@@ -537,7 +562,7 @@ public abstract class BlockWriter{
                writeThisRef();
             }
          }
-         write(assignedField.getConstantPoolFieldEntry().getNameAndTypeEntry().getNameUTF8Entry().getUTF8());
+         write(getOpenCLIdentifier(assignedField.getConstantPoolFieldEntry().getNameAndTypeEntry().getNameUTF8Entry().getUTF8()));
          write("=");
          writeInstruction(assignedField.getValueToAssign());
       } else if (_instruction instanceof Constant<?>) {
@@ -581,13 +606,13 @@ public abstract class BlockWriter{
       } else if (_instruction instanceof AccessLocalVariable) {
          final AccessLocalVariable localVariableLoadInstruction = (AccessLocalVariable) _instruction;
          final LocalVariableInfo localVariable = localVariableLoadInstruction.getLocalVariableInfo();
-         write(localVariable.getVariableName());
+         write(getOpenCLIdentifier(localVariable.getVariableName()));
       } else if (_instruction instanceof I_IINC) {
          final I_IINC location = (I_IINC) _instruction;
          final LocalVariableInfo localVariable = location.getLocalVariableInfo();
          final int adjust = location.getAdjust();
 
-         write(localVariable.getVariableName());
+         write(getOpenCLIdentifier(localVariable.getVariableName()));
          if (adjust == 1) {
             write("++");
          } else if (adjust == -1) {
@@ -688,7 +713,7 @@ public abstract class BlockWriter{
             if (localVariableInfo == null) {
                throw new CodeGenException("outOfScope" + _instruction.getThisPC() + " = ");
             } else {
-               write(localVariableInfo.getVariableName() + " = ");
+               write(getOpenCLIdentifier(localVariableInfo.getVariableName()) + " = ");
             }
 
          }
@@ -703,7 +728,7 @@ public abstract class BlockWriter{
             throw new CodeGenException("/* we can't declare this " + convertType(localVariableInfo.getVariableDescriptor(), true, false)
                   + " here */");
          }
-         write(localVariableInfo.getVariableName());
+         write(getOpenCLIdentifier(localVariableInfo.getVariableName()));
          write("=");
          writeInstruction(inlineAssignInstruction.getRhs());
       } else if (_instruction.getByteCode().equals(ByteCode.FIELD_ARRAY_ELEMENT_ASSIGN)) {

--- a/src/main/java/com/aparapi/internal/writer/KernelWriter.java
+++ b/src/main/java/com/aparapi/internal/writer/KernelWriter.java
@@ -241,7 +241,7 @@ public abstract class KernelWriter extends BlockWriter{
             getterField = m.getAccessorVariableFieldEntry();
          }
          if (getterField != null && isThis(_methodCall.getArg(0))) {
-            String fieldName = getterField.getNameAndTypeEntry().getNameUTF8Entry().getUTF8();
+            String fieldName = getOpenCLIdentifier(getterField.getNameAndTypeEntry().getNameUTF8Entry().getUTF8());
             write("this->");
             write(fieldName);
             return;
@@ -283,8 +283,8 @@ public abstract class KernelWriter extends BlockWriter{
                final AccessArrayElement arrayAccess = (AccessArrayElement) ((VirtualMethodCall) _methodCall).getInstanceReference();
                final Instruction refAccess = arrayAccess.getArrayRef();
                //assert refAccess instanceof I_GETFIELD : "ref should come from getfield";
-               final String fieldName = ((AccessField) refAccess).getConstantPoolFieldEntry().getNameAndTypeEntry()
-                     .getNameUTF8Entry().getUTF8();
+               final String fieldName = getOpenCLIdentifier(((AccessField) refAccess).getConstantPoolFieldEntry().getNameAndTypeEntry()
+                     .getNameUTF8Entry().getUTF8());
                write(" &(this->" + fieldName);
                write("[");
                writeInstruction(arrayAccess.getArrayIndex());
@@ -343,6 +343,8 @@ public abstract class KernelWriter extends BlockWriter{
          final StringBuilder thisStructLine = new StringBuilder();
          final StringBuilder argLine = new StringBuilder();
          final StringBuilder assignLine = new StringBuilder();
+         final String fieldName = field.getName();
+         final String openCLFieldName = getOpenCLIdentifier(fieldName);
 
          String signature = field.getDescriptor();
 
@@ -352,11 +354,11 @@ public abstract class KernelWriter extends BlockWriter{
 
          // check the suffix
 
-         String type = field.getName().endsWith(Kernel.LOCAL_SUFFIX) ? __local
-               : (field.getName().endsWith(Kernel.CONSTANT_SUFFIX) ? __constant : __global);
+         String type = fieldName.endsWith(Kernel.LOCAL_SUFFIX) ? __local
+               : (fieldName.endsWith(Kernel.CONSTANT_SUFFIX) ? __constant : __global);
          Integer privateMemorySize = null;
          try {
-            privateMemorySize = _entryPoint.getClassModel().getPrivateMemorySize(field.getName());
+            privateMemorySize = _entryPoint.getClassModel().getPrivateMemorySize(fieldName);
          } catch (ClassParseException e) {
             throw new CodeGenException(e);
          }
@@ -423,13 +425,13 @@ public abstract class KernelWriter extends BlockWriter{
 
          if (privateMemorySize == null) {
             assignLine.append("this->");
-            assignLine.append(field.getName());
+            assignLine.append(openCLFieldName);
             assignLine.append(" = ");
-            assignLine.append(field.getName());
+            assignLine.append(openCLFieldName);
          }
 
-         argLine.append(field.getName());
-         thisStructLine.append(field.getName());
+         argLine.append(openCLFieldName);
+         thisStructLine.append(openCLFieldName);
          if (privateMemorySize == null) {
             assigns.add(assignLine.toString());
          }
@@ -441,7 +443,7 @@ public abstract class KernelWriter extends BlockWriter{
 
          // Add int field into "this" struct for supporting java arraylength op
          // named like foo__javaArrayLength
-         if (isPointer && _entryPoint.getArrayFieldArrayLengthUsed().contains(field.getName()) || isPointer && numDimensions > 1) {
+         if (isPointer && _entryPoint.getArrayFieldArrayLengthUsed().contains(fieldName) || isPointer && numDimensions > 1) {
 
             for (int i = 0; i < numDimensions; i++) {
                final StringBuilder lenStructLine = new StringBuilder();
@@ -449,7 +451,7 @@ public abstract class KernelWriter extends BlockWriter{
                final StringBuilder lenAssignLine = new StringBuilder();
 
                String suffix = numDimensions == 1 ? "" : Integer.toString(i);
-               String lenName = field.getName() + BlockWriter.arrayLengthMangleSuffix + suffix;
+               String lenName = openCLFieldName + BlockWriter.arrayLengthMangleSuffix + suffix;
 
                lenStructLine.append("int " + lenName);
 
@@ -468,7 +470,7 @@ public abstract class KernelWriter extends BlockWriter{
                   final StringBuilder dimStructLine = new StringBuilder();
                   final StringBuilder dimArgLine = new StringBuilder();
                   final StringBuilder dimAssignLine = new StringBuilder();
-                  String dimName = field.getName() + BlockWriter.arrayDimMangleSuffix + suffix;
+                  String dimName = openCLFieldName + BlockWriter.arrayDimMangleSuffix + suffix;
 
                   dimStructLine.append("int " + dimName);
 
@@ -562,7 +564,7 @@ public abstract class KernelWriter extends BlockWriter{
 
                final String cType = convertType(field.getNameAndTypeEntry().getDescriptorUTF8Entry().getUTF8(), true, false);
                assert cType != null : "could not find type for " + field.getNameAndTypeEntry().getDescriptorUTF8Entry().getUTF8();
-               writeln(cType + " " + field.getNameAndTypeEntry().getNameUTF8Entry().getUTF8() + ";");
+               writeln(cType + " " + getOpenCLIdentifier(field.getNameAndTypeEntry().getNameUTF8Entry().getUTF8()) + ";");
             }
 
             // compute total size for OpenCL buffer
@@ -687,7 +689,7 @@ public abstract class KernelWriter extends BlockWriter{
                }
                
                write(convertType(descriptor, true, false));
-               write(lvi.getVariableName());
+               write(getOpenCLIdentifier(lvi.getVariableName()));
                alreadyHasFirstArg = true;
                
                localVariableIndex++;

--- a/src/test/java/com/aparapi/codegen/test/ReservedOpenCLKeywordNamesTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReservedOpenCLKeywordNamesTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016 - 2018 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.aparapi.codegen.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.aparapi.Kernel;
+import com.aparapi.internal.model.ClassModel;
+import com.aparapi.internal.model.Entrypoint;
+import com.aparapi.internal.writer.KernelWriter;
+
+public class ReservedOpenCLKeywordNamesTest {
+
+   @Test
+   public void manglesReservedFieldAndLocalVariableNames() throws Exception {
+      ClassModel classModel = ClassModel.createClassModel(ReservedKeywordKernel.class);
+      Entrypoint entrypoint = classModel.getEntrypoint("run", new ReservedKeywordKernel());
+      String openCL = KernelWriter.writeToString(entrypoint);
+
+      assertTrue(openCL.contains("__local float *aparapi_local"));
+      assertTrue(openCL.contains("this->aparapi_local = aparapi_local;"));
+      assertTrue(openCL.contains("int aparapi_kernel = "));
+      assertTrue(openCL.contains("this->aparapi_local[aparapi_kernel]"));
+
+      assertFalse(openCL.contains("__local float *local"));
+      assertFalse(openCL.contains("this->local"));
+      assertFalse(openCL.contains("int kernel = "));
+   }
+
+   public static class ReservedKeywordKernel extends Kernel {
+      @Local final float[] local = new float[16];
+      final int[] result = new int[1];
+
+      @Override
+      public void run() {
+         int kernel = getGlobalId(0);
+         local[kernel] = kernel;
+         result[0] = kernel;
+      }
+   }
+}


### PR DESCRIPTION
## Summary
- Add OpenCL reserved identifier mangling for generated field, parameter, and local variable names.
- Keep Java metadata lookups on the original field names while emitting safe OpenCL identifiers such as `aparapi_local`.
- Add a codegen regression test for a `@Local` field named `local` and a local variable named `kernel`.

Refs #54.

## Verification
- `git diff --check`
- Unable to run `mvn -Dtest=com.aparapi.codegen.test.ReservedOpenCLKeywordNamesTest test` locally because this environment has no `mvn`, no Maven wrapper, and no Java runtime installed.

If this is accepted for the $25 bounty, I can provide payout details.