### PR TITLE
Fix inline declaration codegen

### DIFF
--- a/src/main/java/com/aparapi/internal/writer/BlockWriter.java
+++ b/src/main/java/com/aparapi/internal/writer/BlockWriter.java
@@ -295,7 +295,14 @@ public abstract class BlockWriter{
 
       for (Instruction instruction = _first; instruction != _last; instruction = instruction.getNextExpr()) {
          if (instruction instanceof CompositeInstruction) {
-            writeComposite((CompositeInstruction) instruction);
+            final Set<String> inlineAssignDeclarations = new HashSet<String>();
+            writeInlineAssignDeclarations(instruction, inlineAssignDeclarations);
+            inlineAssignDeclarationScopes.push(inlineAssignDeclarations);
+            try {
+               writeComposite((CompositeInstruction) instruction);
+            } finally {
+               inlineAssignDeclarationScopes.pop();
+            }
          } else if (!instruction.getByteCode().equals(ByteCode.NONE)) {
             final Set<String> inlineAssignDeclarations = new HashSet<String>();
             writeInlineAssignDeclarations(instruction, inlineAssignDeclarations);
@@ -318,28 +325,17 @@ public abstract class BlockWriter{
          return;
       }
 
+      if (_instruction instanceof CompositeInstruction) {
+         writeInlineAssignDeclarations(_instruction.getFirstChild(), _instruction.getLastChild().getNextExpr(), _declaredVariables);
+         return;
+      }
+
       if (_instruction.getByteCode().equals(ByteCode.INLINE_ASSIGN)) {
          final InlineAssignInstruction inlineAssignInstruction = (InlineAssignInstruction) _instruction;
-         final AssignToLocalVariable assignToLocalVariable = inlineAssignInstruction.getAssignToLocalVariable();
-         final LocalVariableInfo localVariableInfo = assignToLocalVariable.getLocalVariableInfo();
-         if (assignToLocalVariable.isDeclaration()) {
-            if (localVariableInfo == null) {
-               throw new CodeGenException("outOfScope" + _instruction.getThisPC() + " = ");
-            }
-
-            final String declarationKey = getDeclarationKey(localVariableInfo);
-            if (_declaredVariables.add(declarationKey)) {
-               final String descriptor = localVariableInfo.getVariableDescriptor();
-               newLine();
-               if (descriptor.startsWith("[")) {
-                  write(" __global ");
-               }
-               write(convertType(descriptor, true, false));
-               write(localVariableInfo.getVariableName());
-               write(";");
-            }
-         }
+         writeInlineAssignDeclaration(inlineAssignInstruction.getAssignToLocalVariable(), _declaredVariables);
          writeInlineAssignDeclarations(inlineAssignInstruction.getRhs(), _declaredVariables);
+      } else if (_instruction instanceof AssignToLocalVariable && _instruction.getParentExpr() != null) {
+         writeInlineAssignDeclaration((AssignToLocalVariable) _instruction, _declaredVariables);
       }
 
       for (Instruction operand = _instruction.getFirstChild(); operand != null; operand = operand.getNextExpr()) {
@@ -347,8 +343,37 @@ public abstract class BlockWriter{
       }
    }
 
+   private void writeInlineAssignDeclarations(Instruction _first, Instruction _last, Set<String> _declaredVariables) throws CodeGenException {
+      for (Instruction instruction = _first; instruction != _last; instruction = instruction.getNextExpr()) {
+         writeInlineAssignDeclarations(instruction, _declaredVariables);
+      }
+   }
+
+   private void writeInlineAssignDeclaration(AssignToLocalVariable _assignToLocalVariable, Set<String> _declaredVariables)
+         throws CodeGenException {
+      final LocalVariableInfo localVariableInfo = _assignToLocalVariable.getLocalVariableInfo();
+      if (_assignToLocalVariable.isDeclaration()) {
+         if (localVariableInfo == null) {
+            throw new CodeGenException("outOfScope" + ((Instruction) _assignToLocalVariable).getThisPC() + " = ");
+         }
+
+         final String declarationKey = getDeclarationKey(localVariableInfo);
+         if (_declaredVariables.add(declarationKey) && !isInlineAssignDeclarationHoisted(localVariableInfo)) {
+            final String descriptor = localVariableInfo.getVariableDescriptor();
+            newLine();
+            if (descriptor.startsWith("[")) {
+               write(" __global ");
+            }
+            write(convertType(descriptor, true, false));
+            write(localVariableInfo.getVariableName());
+            write(";");
+         }
+      }
+   }
+
    private String getDeclarationKey(LocalVariableInfo _localVariableInfo) {
-      return (_localVariableInfo.getVariableIndex() + ":" + _localVariableInfo.getStart());
+      return (_localVariableInfo.getVariableIndex() + ":" + _localVariableInfo.getVariableDescriptor() + ":"
+            + _localVariableInfo.getVariableName());
    }
 
    private boolean isInlineAssignDeclarationHoisted(LocalVariableInfo _localVariableInfo) {
@@ -477,7 +502,8 @@ public abstract class BlockWriter{
                  write(localVariableInfo.getVariableName());
              }
          } else {
-             if (assignToLocalVariable.isDeclaration()) {
+             if (assignToLocalVariable.isDeclaration() && _instruction.getParentExpr() == null
+                   && !isInlineAssignDeclarationHoisted(localVariableInfo)) {
                  final String descriptor = localVariableInfo.getVariableDescriptor();
                  // Arrays always map to __global arrays
                  if (descriptor.startsWith("[")) {
@@ -739,14 +765,13 @@ public abstract class BlockWriter{
          for (AssignToLocalVariable alv = stack.pop(); alv != null; alv = stack.size() > 0 ? stack.pop() : null) {
 
             final LocalVariableInfo localVariableInfo = alv.getLocalVariableInfo();
-            if (alv.isDeclaration()) {
-               write(convertType(localVariableInfo.getVariableDescriptor(), true, false));
-            }
             if (localVariableInfo == null) {
                throw new CodeGenException("outOfScope" + _instruction.getThisPC() + " = ");
-            } else {
-               write(localVariableInfo.getVariableName() + " = ");
             }
+            if (alv.isDeclaration() && !isInlineAssignDeclarationHoisted(localVariableInfo)) {
+               write(convertType(localVariableInfo.getVariableDescriptor(), true, false));
+            }
+            write(localVariableInfo.getVariableName() + " = ");
 
          }
          writeInstruction(common);

--- a/src/main/java/com/aparapi/internal/writer/BlockWriter.java
+++ b/src/main/java/com/aparapi/internal/writer/BlockWriter.java
@@ -80,6 +80,8 @@ public abstract class BlockWriter{
 
    public final static String arrayDimMangleSuffix = "__javaArrayDimension";
 
+   private final Stack<Set<String>> inlineAssignDeclarationScopes = new Stack<Set<String>>();
+
    public abstract void write(String _string);
 
    public void writeln(String _string) {
@@ -295,13 +297,68 @@ public abstract class BlockWriter{
          if (instruction instanceof CompositeInstruction) {
             writeComposite((CompositeInstruction) instruction);
          } else if (!instruction.getByteCode().equals(ByteCode.NONE)) {
-            newLine();
-            writeInstruction(instruction);
-            write(";");
+            final Set<String> inlineAssignDeclarations = new HashSet<String>();
+            writeInlineAssignDeclarations(instruction, inlineAssignDeclarations);
+            inlineAssignDeclarationScopes.push(inlineAssignDeclarations);
+            try {
+               newLine();
+               writeInstruction(instruction);
+               write(";");
+            } finally {
+               inlineAssignDeclarationScopes.pop();
+            }
 
          }
       }
 
+   }
+
+   private void writeInlineAssignDeclarations(Instruction _instruction, Set<String> _declaredVariables) throws CodeGenException {
+      if (_instruction == null) {
+         return;
+      }
+
+      if (_instruction.getByteCode().equals(ByteCode.INLINE_ASSIGN)) {
+         final InlineAssignInstruction inlineAssignInstruction = (InlineAssignInstruction) _instruction;
+         final AssignToLocalVariable assignToLocalVariable = inlineAssignInstruction.getAssignToLocalVariable();
+         final LocalVariableInfo localVariableInfo = assignToLocalVariable.getLocalVariableInfo();
+         if (assignToLocalVariable.isDeclaration()) {
+            if (localVariableInfo == null) {
+               throw new CodeGenException("outOfScope" + _instruction.getThisPC() + " = ");
+            }
+
+            final String declarationKey = getDeclarationKey(localVariableInfo);
+            if (_declaredVariables.add(declarationKey)) {
+               final String descriptor = localVariableInfo.getVariableDescriptor();
+               newLine();
+               if (descriptor.startsWith("[")) {
+                  write(" __global ");
+               }
+               write(convertType(descriptor, true, false));
+               write(localVariableInfo.getVariableName());
+               write(";");
+            }
+         }
+         writeInlineAssignDeclarations(inlineAssignInstruction.getRhs(), _declaredVariables);
+      }
+
+      for (Instruction operand = _instruction.getFirstChild(); operand != null; operand = operand.getNextExpr()) {
+         writeInlineAssignDeclarations(operand, _declaredVariables);
+      }
+   }
+
+   private String getDeclarationKey(LocalVariableInfo _localVariableInfo) {
+      return (_localVariableInfo.getVariableIndex() + ":" + _localVariableInfo.getStart());
+   }
+
+   private boolean isInlineAssignDeclarationHoisted(LocalVariableInfo _localVariableInfo) {
+      final String declarationKey = getDeclarationKey(_localVariableInfo);
+      for (Set<String> declarationScope : inlineAssignDeclarationScopes) {
+         if (declarationScope.contains(declarationKey)) {
+            return true;
+         }
+      }
+      return false;
    }
 
    protected void writeGetterBlock(FieldEntry accessorVariableFieldEntry) {
@@ -698,8 +755,10 @@ public abstract class BlockWriter{
          final AssignToLocalVariable assignToLocalVariable = inlineAssignInstruction.getAssignToLocalVariable();
 
          final LocalVariableInfo localVariableInfo = assignToLocalVariable.getLocalVariableInfo();
-         if (assignToLocalVariable.isDeclaration()) {
-            // this is bad! we need a general way to hoist up a required declaration
+         if (localVariableInfo == null) {
+            throw new CodeGenException("outOfScope" + _instruction.getThisPC() + " = ");
+         }
+         if (assignToLocalVariable.isDeclaration() && !isInlineAssignDeclarationHoisted(localVariableInfo)) {
             throw new CodeGenException("/* we can't declare this " + convertType(localVariableInfo.getVariableDescriptor(), true, false)
                   + " here */");
          }

--- a/src/test/java/com/aparapi/codegen/test/AssignAndPassAsParameterSimple.java
+++ b/src/test/java/com/aparapi/codegen/test/AssignAndPassAsParameterSimple.java
@@ -26,4 +26,29 @@ public class AssignAndPassAsParameterSimple {
         actuallyDoIt(z = 1);
     }
 }
-/**{Throws{CodeGenException}Throws}**/
+/**{OpenCL{
+ typedef struct This_s{
+
+ int passid;
+ }This;
+ int get_pass_id(This *this){
+ return this->passid;
+ }
+
+ void com_aparapi_codegen_test_AssignAndPassAsParameterSimple__actuallyDoIt(This *this, int a){
+ return;
+ }
+ __kernel void run(
+ int passid
+ ){
+ This thisStruct;
+ This* this=&thisStruct;
+ this->passid = passid;
+ {
+ int z;
+ com_aparapi_codegen_test_AssignAndPassAsParameterSimple__actuallyDoIt(this, z=1);
+ return;
+ }
+ }
+
+ }OpenCL}**/

--- a/src/test/java/com/aparapi/codegen/test/AssignAndPassAsParameterSimpleTest.java
+++ b/src/test/java/com/aparapi/codegen/test/AssignAndPassAsParameterSimpleTest.java
@@ -15,15 +15,36 @@
  */
 package com.aparapi.codegen.test;
 
-import com.aparapi.internal.exception.ClassParseException;
-import com.aparapi.internal.exception.CodeGenException;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class AssignAndPassAsParameterSimpleTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = null;
-    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = CodeGenException.class;
+    private static final String[] expectedOpenCL = {
+        "typedef struct This_s{\n"
+        + "\n"
+        + " int passid;\n"
+        + " }This;\n"
+        + " int get_pass_id(This *this){\n"
+        + " return this->passid;\n"
+        + " }\n"
+        + "\n"
+        + " void com_aparapi_codegen_test_AssignAndPassAsParameterSimple__actuallyDoIt(This *this, int a){\n"
+        + " return;\n"
+        + " }\n"
+        + " __kernel void run(\n"
+        + " int passid\n"
+        + " ){\n"
+        + " This thisStruct;\n"
+        + " This* this=&thisStruct;\n"
+        + " this->passid = passid;\n"
+        + " {\n"
+        + " int z;\n"
+        + " com_aparapi_codegen_test_AssignAndPassAsParameterSimple__actuallyDoIt(this, z=1);\n"
+        + " return;\n"
+        + " }\n"
+        + " }\n"
+        + " "};
+    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test
     public void AssignAndPassAsParameterSimpleTest() {

--- a/src/test/java/com/aparapi/codegen/test/FirstAssignInExpression2.java
+++ b/src/test/java/com/aparapi/codegen/test/FirstAssignInExpression2.java
@@ -48,15 +48,16 @@ public class FirstAssignInExpression2 {
  this->passid = passid;
  {
  int value = 1;
- int result=0;
- int assignMe=0;
- if (true){
+ int result = 0;
+ int assignMe;
+ if (value==value){
  result = assignMe = value;
  }else{
  assignMe =1;
  result=2;
  }
  result++;
+ assignMe++;
  return;
  }
  }

--- a/src/test/java/com/aparapi/codegen/test/FirstAssignInExpression2Test.java
+++ b/src/test/java/com/aparapi/codegen/test/FirstAssignInExpression2Test.java
@@ -15,7 +15,6 @@
  */
 package com.aparapi.codegen.test;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class FirstAssignInExpression2Test extends com.aparapi.codegen.CodeGenJUnitBase {
@@ -36,28 +35,27 @@ public class FirstAssignInExpression2Test extends com.aparapi.codegen.CodeGenJUn
         + " this->passid = passid;\n"
         + " {\n"
         + " int value = 1;\n"
-        + " int result=0;\n"
-        + " int assignMe=0;\n"
-        + " if (true){\n"
+        + " int result = 0;\n"
+        + " int assignMe;\n"
+        + " if (value==value){\n"
         + " result = assignMe = value;\n"
         + " }else{\n"
         + " assignMe =1;\n"
         + " result=2;\n"
         + " }\n"
         + " result++;\n"
+        + " assignMe++;\n"
         + " return;\n"
         + " }\n"
         + " }\n"
         + " "};
     private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
-    @Ignore
     @Test
     public void FirstAssignInExpression2Test() {
         test(com.aparapi.codegen.test.FirstAssignInExpression2.class, expectedException, expectedOpenCL);
     }
 
-    @Ignore
     @Test
     public void FirstAssignInExpression2TestWorksWithCaching() {
         test(com.aparapi.codegen.test.FirstAssignInExpression2.class, expectedException, expectedOpenCL);


### PR DESCRIPTION
Fixes #97.
Fixes #99.

This hoists declarations for locals whose first assignment appears inside inline assignment and chained multi-assignment expressions, then emits the expression as a normal assignment. That prevents invalid declaration-in-expression OpenCL such as `result = int assignMe = value;` while preserving the existing guard for unhandled inline declaration contexts.

Validation run locally:
- Direct JDK 11 compile plus JUnitCore: `FirstAssignInExpression2Test`, `AssignAndPassAsParameterSimpleTest`, `AssignAndPassAsParameterTest`, `ConstantAssignInExpressionTest`, `MultipleAssignExprTest` - 10 tests OK.
- `git diff --check`

I also attempted the equivalent focused Maven test target, but this sandbox blocked `scala-maven-plugin` when it tried to create `/Users/jpappas/.sbt`.