### PR TITLE
Track static array field reads and writes

### DIFF
--- a/src/main/java/com/aparapi/internal/model/Entrypoint.java
+++ b/src/main/java/com/aparapi/internal/model/Entrypoint.java
@@ -554,9 +554,9 @@ public class Entrypoint implements Cloneable {
 
                final Instruction arrayRef = assignment.getArrayRef();
                // AccessField here allows instance and static array refs
-               if (arrayRef instanceof I_GETFIELD) {
-                  final I_GETFIELD getField = (I_GETFIELD) arrayRef;
-                  final FieldEntry field = getField.getConstantPoolFieldEntry();
+               if (arrayRef instanceof AccessField) {
+                  final AccessField accessField = (AccessField) arrayRef;
+                  final FieldEntry field = accessField.getConstantPoolFieldEntry();
                   final String assignedArrayFieldName = field.getNameAndTypeEntry().getNameUTF8Entry().getUTF8();
                   arrayFieldAssignments.add(assignedArrayFieldName);
                   referencedFieldNames.add(assignedArrayFieldName);
@@ -567,9 +567,9 @@ public class Entrypoint implements Cloneable {
 
                final Instruction arrayRef = access.getArrayRef();
                // AccessField here allows instance and static array refs
-               if (arrayRef instanceof I_GETFIELD) {
-                  final I_GETFIELD getField = (I_GETFIELD) arrayRef;
-                  final FieldEntry field = getField.getConstantPoolFieldEntry();
+               if (arrayRef instanceof AccessField) {
+                  final AccessField accessField = (AccessField) arrayRef;
+                  final FieldEntry field = accessField.getConstantPoolFieldEntry();
                   final String accessedArrayFieldName = field.getNameAndTypeEntry().getNameUTF8Entry().getUTF8();
                   arrayFieldAccesses.add(accessedArrayFieldName);
                   referencedFieldNames.add(accessedArrayFieldName);

--- a/src/test/java/com/aparapi/runtime/StaticArrayAssignmentEntrypointTest.java
+++ b/src/test/java/com/aparapi/runtime/StaticArrayAssignmentEntrypointTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2016 - 2018 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.aparapi.runtime;
+
+import com.aparapi.Kernel;
+import com.aparapi.internal.model.ClassModel;
+import com.aparapi.internal.model.Entrypoint;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class StaticArrayAssignmentEntrypointTest {
+    @Test
+    public void staticArrayReadsAndWritesAreTracked() throws Exception {
+        ClassModel classModel = ClassModel.createClassModel(StaticArrayAssignmentKernel.class);
+        Entrypoint entrypoint = classModel.getEntrypoint("run", new StaticArrayAssignmentKernel());
+
+        assertTrue(entrypoint.getArrayFieldAssignments().contains("target"));
+        assertTrue(entrypoint.getArrayFieldAccesses().contains("source"));
+    }
+
+    public static class StaticArrayAssignmentKernel extends Kernel {
+        static final int size = 32;
+
+        static int[] source = new int[size];
+        static int[] target = new int[size];
+
+        @Override
+        public void run() {
+            int id = getGlobalId();
+            target[id] = source[id];
+        }
+    }
+}


### PR DESCRIPTION
Fixes #86.

This updates entrypoint field tracking so array element reads and writes through static fields are handled the same way as instance fields. The existing comments already described `AccessField` as the intended abstraction for both instance and static array refs, but the implementation only accepted `I_GETFIELD`, so `I_GETSTATIC` array refs were skipped.

Added a regression test that builds an `Entrypoint` for a kernel copying from one static array to another and verifies the source is tracked as an array field access while the target is tracked as an array field assignment.

Validation:
- `mvn -q -Dmaven.repo.local=/private/tmp/aparapi-m2 -DsecondaryCacheDir=/private/tmp/aparapi-zinc-jdk11 -DargLine="-XX:+IgnoreUnrecognizedVMOptions" -Dtest=com.aparapi.runtime.StaticArrayAssignmentEntrypointTest test`
- `mvn -q -Dmaven.repo.local=/private/tmp/aparapi-m2 -DsecondaryCacheDir=/private/tmp/aparapi-zinc-jdk11 -DargLine="-XX:+IgnoreUnrecognizedVMOptions" -Dtest=com.aparapi.runtime.StaticArrayAssignmentEntrypointTest,com.aparapi.codegen.test.ClassHasStaticFieldAccessTest,com.aparapi.codegen.test.StaticFieldStoreTest test`
- `mvn -q -Dmaven.repo.local=/private/tmp/aparapi-m2 -DsecondaryCacheDir=/private/tmp/aparapi-zinc-jdk11 -DargLine="-XX:+IgnoreUnrecognizedVMOptions" -DskipTests package`