### PR TITLE
Inline final null array references

### DIFF
--- a/src/main/java/com/aparapi/internal/kernel/KernelRunner.java
+++ b/src/main/java/com/aparapi/internal/kernel/KernelRunner.java
@@ -1727,6 +1727,10 @@ public class KernelRunner extends KernelRunnerJNI{
                   int i = 0;
 
                   for (final Field field : entryPoint.getReferencedFields()) {
+                     if (entryPoint.canInlineNullArrayField(field.getName())) {
+                        continue;
+                     }
+
                      try {
                         field.setAccessible(true);
                         args[i] = new KernelArg();

--- a/src/main/java/com/aparapi/internal/model/Entrypoint.java
+++ b/src/main/java/com/aparapi/internal/model/Entrypoint.java
@@ -143,6 +143,39 @@ public class Entrypoint implements Cloneable {
       return kernelInstance;
    }
 
+   public boolean canInlineNullArrayField(String fieldName) {
+      try {
+         final Field field = getFieldFromClassHierarchy(classModel.getClassWeAreModelling(), fieldName);
+         return canInlineNullArrayField(field);
+      } catch (final AparapiException e) {
+         return false;
+      }
+   }
+
+   private boolean canInlineNullArrayField(Field field) {
+      if ((field == null) || !field.getType().isArray() || !Modifier.isFinal(field.getModifiers())) {
+         return false;
+      }
+
+      final String fieldName = field.getName();
+      if (arrayFieldAccesses.contains(fieldName) || arrayFieldAssignments.contains(fieldName)
+            || arrayFieldArrayLengthUsed.contains(fieldName)) {
+         return false;
+      }
+
+      try {
+         if (!Modifier.isStatic(field.getModifiers()) && (kernelInstance == null)) {
+            return false;
+         }
+         field.setAccessible(true);
+         return field.get(Modifier.isStatic(field.getModifiers()) ? null : kernelInstance) == null;
+      } catch (final RuntimeException e) {
+         return false;
+      } catch (final IllegalAccessException e) {
+         return false;
+      }
+   }
+
    public void setKernelInstance(Object _k) {
       kernelInstance = _k;
    }
@@ -704,7 +737,7 @@ public class Entrypoint implements Cloneable {
          try {
             final Class<?> clazz = classModel.getClassWeAreModelling();
             final Field field = getFieldFromClassHierarchy(clazz, referencedFieldName);
-            if (field != null) {
+            if ((field != null) && !canInlineNullArrayField(field)) {
                referencedFields.add(field);
                final ClassModelField ff = classModel.getField(referencedFieldName);
                assert ff != null : "ff should not be null for " + clazz.getName() + "." + referencedFieldName;

--- a/src/main/java/com/aparapi/internal/writer/KernelWriter.java
+++ b/src/main/java/com/aparapi/internal/writer/KernelWriter.java
@@ -339,6 +339,10 @@ public abstract class KernelWriter extends BlockWriter{
       entryPoint = _entryPoint;
 
       for (final ClassModelField field : _entryPoint.getReferencedClassModelFields()) {
+         if (_entryPoint.canInlineNullArrayField(field.getName())) {
+            continue;
+         }
+
          // Field field = _entryPoint.getClassModel().getField(f.getName());
          final StringBuilder thisStructLine = new StringBuilder();
          final StringBuilder argLine = new StringBuilder();
@@ -747,7 +751,15 @@ public abstract class KernelWriter extends BlockWriter{
    }
 
    @Override public void writeInstruction(Instruction _instruction) throws CodeGenException {
-      if ((_instruction instanceof I_IUSHR) || (_instruction instanceof I_LUSHR)) {
+      if (_instruction instanceof AccessField) {
+         final AccessField accessField = (AccessField) _instruction;
+         final String fieldName = accessField.getConstantPoolFieldEntry().getNameAndTypeEntry().getNameUTF8Entry().getUTF8();
+         if (entryPoint.canInlineNullArrayField(fieldName)) {
+            write("NULL");
+         } else {
+            super.writeInstruction(_instruction);
+         }
+      } else if ((_instruction instanceof I_IUSHR) || (_instruction instanceof I_LUSHR)) {
          final BinaryOperator binaryInstruction = (BinaryOperator) _instruction;
          final Instruction parent = binaryInstruction.getParentExpr();
          boolean needsParenthesis = true;

--- a/src/test/java/com/aparapi/runtime/NullRefTest.java
+++ b/src/test/java/com/aparapi/runtime/NullRefTest.java
@@ -16,14 +16,29 @@
 package com.aparapi.runtime;
 
 import com.aparapi.Kernel;
-import org.junit.Ignore;
+import com.aparapi.internal.model.ClassModel;
+import com.aparapi.internal.model.Entrypoint;
+import com.aparapi.internal.writer.KernelWriter;
 import org.junit.Test;
 
+import static org.junit.Assert.assertTrue;
+
 public class NullRefTest {
-    @Ignore("Known bug, runs on CPU but not GPU.")
     @Test
     public void test() {
         new NullRefTest().doTest();
+    }
+
+    @Test
+    public void finalNullArrayIsInlinedInGeneratedOpenCL() throws Exception {
+        NullRefKernel kernel = new NullRefKernel();
+        ClassModel classModel = ClassModel.createClassModel(kernel.getClass());
+        Entrypoint entrypoint = classModel.getEntrypoint("run", kernel);
+
+        String openCL = KernelWriter.writeToString(entrypoint);
+        assertTrue(entrypoint.canInlineNullArrayField("nullArray"));
+        assertTrue(openCL.contains("if (NULL == NULL)"));
+        assertTrue(!openCL.contains("nullArray"));
     }
 
     private void doTest() {


### PR DESCRIPTION
Fixes #92.

The disabled `NullRefTest` uses a `final` array field whose value is `null` and only checks it against `null` inside the kernel. Before this change, Aparapi still emitted that field as an OpenCL pointer argument, so `KernelRunner.updateKernelArrayRefs()` tried to sync the null array and threw before GPU execution could evaluate the null check.

This change treats final null array fields that are only used for null checks as compile-time `NULL` values:
- `Entrypoint` identifies final null array fields that are not accessed, assigned, or used for `.length`.
- `KernelWriter` omits those fields from the generated kernel argument/`This` struct and emits `NULL` at field-use sites.
- `KernelRunner` skips creating runtime args for those inlined fields when cached entrypoints still contain the original field metadata.
- `NullRefTest` is re-enabled and now asserts the generated OpenCL inlines `NULL` instead of declaring/passing `nullArray`.

Validation:
- `mvn -q -Dmaven.repo.local=/private/tmp/aparapi-m2 -DsecondaryCacheDir=/private/tmp/aparapi-zinc-jdk11 -DargLine="-XX:+IgnoreUnrecognizedVMOptions" -Dtest=com.aparapi.runtime.NullRefTest test`
- `mvn -q -Dmaven.repo.local=/private/tmp/aparapi-m2 -DsecondaryCacheDir=/private/tmp/aparapi-zinc-jdk11 -DargLine="-XX:+IgnoreUnrecognizedVMOptions" -Dtest=com.aparapi.runtime.NullRefTest,com.aparapi.runtime.BufferTransferTest,com.aparapi.codegen.test.NonNullCheckTest,com.aparapi.codegen.test.ObjectArrayMemberAccessTest test`
- `mvn -q -Dmaven.repo.local=/private/tmp/aparapi-m2 -DsecondaryCacheDir=/private/tmp/aparapi-zinc-jdk11 -DargLine="-XX:+IgnoreUnrecognizedVMOptions" -DskipTests package`
- `git diff --check`

Note: this local environment does not have the OpenCL native library available, so direct GPU execution logs the existing OpenCL loader warning locally. The regression coverage checks the Java-side codegen/argument path that previously declared and synced the final null array.