### PR TITLE
Fix synthetic long local declarations

### DIFF
--- a/src/main/java/com/aparapi/internal/model/MethodModel.java
+++ b/src/main/java/com/aparapi/internal/model/MethodModel.java
@@ -1484,7 +1484,7 @@ public class MethodModel{
                descriptor = "/* arg */";
             } else {
                name = _storeSpec.toString().toLowerCase() + "_" + _slotIndex;
-               descriptor = _storeSpec.toString();
+               descriptor = _storeSpec.equals(StoreSpec.L) ? Character.toString(ClassModel.SIGC_LONG) : _storeSpec.toString();
             }
          }
 

--- a/src/test/java/com/aparapi/codegen/test/LongVariableDeclarationWithCastNoDebugInfoTest.java
+++ b/src/test/java/com/aparapi/codegen/test/LongVariableDeclarationWithCastNoDebugInfoTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2016 - 2018 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.aparapi.codegen.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
+import org.junit.Test;
+
+import com.aparapi.internal.model.ClassModel;
+import com.aparapi.internal.model.Entrypoint;
+import com.aparapi.internal.writer.KernelWriter;
+
+public class LongVariableDeclarationWithCastNoDebugInfoTest {
+
+   @Test
+   public void declaresLongLocalInitializedFromCastWithoutDebugInfo() throws Exception {
+      final String openCL = generateOpenCLFromFixtureWithoutDebugInfo();
+
+      assertTrue(openCL, openCL.contains("long l_3=(long)i_1;") || openCL.contains("long l_3 = (long)i_1;"));
+   }
+
+   private String generateOpenCLFromFixtureWithoutDebugInfo() throws Exception {
+      final Path sourceDir = Files.createTempDirectory("aparapi-no-debug-src");
+      final Path classesDir = Files.createTempDirectory("aparapi-no-debug-classes");
+      final Path packageDir = sourceDir.resolve("com/aparapi/codegen/generated");
+      Files.createDirectories(packageDir);
+
+      final Path sourceFile = packageDir.resolve("LongVariableDeclarationWithCastNoDebugInfo.java");
+      final String source = ""
+            + "package com.aparapi.codegen.generated;\n"
+            + "public class LongVariableDeclarationWithCastNoDebugInfo {\n"
+            + "   public void run() {\n"
+            + "      int idx = 1;\n"
+            + "      int iter = 25000;\n"
+            + "      long seed = (long) idx;\n"
+            + "      float sum = 0.0f;\n"
+            + "      seed = seed + 1L;\n"
+            + "      sum = sum + (float) seed + (float) iter;\n"
+            + "   }\n"
+            + "}\n";
+      Files.write(sourceFile, source.getBytes(StandardCharsets.UTF_8));
+
+      final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+      assertNotNull("This test requires a JDK, not just a JRE", compiler);
+      final int result = compiler.run(null, null, null, "-g:none", "-classpath", System.getProperty("java.class.path"),
+            "-d", classesDir.toString(), sourceFile.toString());
+      assertEquals(0, result);
+
+      final URL[] urls = new URL[] { classesDir.toUri().toURL() };
+      try (URLClassLoader classLoader = new URLClassLoader(urls, getClass().getClassLoader())) {
+         final Class<?> fixture = Class.forName("com.aparapi.codegen.generated.LongVariableDeclarationWithCastNoDebugInfo",
+               true, classLoader);
+         final Object fixtureInstance = fixture.getConstructor((Class<?>[]) null).newInstance();
+         final ClassModel classModel = ClassModel.createClassModel(fixture);
+         final Entrypoint entrypoint = classModel.getEntrypoint("run", fixtureInstance);
+         return KernelWriter.writeToString(entrypoint);
+      }
+   }
+}


### PR DESCRIPTION
## Summary

Fixes #10.

When Aparapi has to synthesize a local variable table for bytecode compiled without `-g`, long locals were recorded with descriptor `L`. In JVM descriptors, `L` starts an object reference type; scalar long is `J`. That made the generated OpenCL omit the declaration for locals such as `long seed = (long) idx;`, producing output like `l_3 = (long)i_1;`.

## Changes

- Map synthetic long local descriptors to JVM descriptor `J`.
- Add a regression test that compiles a fixture with `-g:none` and checks that the generated OpenCL declares `long l_3` for the cast-initialized local.

## Verification

```bash
JAVA_HOME=/private/tmp/jdk-11 PATH=/private/tmp/apache-maven-3.9.11/bin:/private/tmp/jdk-11/bin:$PATH mvn -q -Dmaven.repo.local=/private/tmp/aparapi-m2 -DsecondaryCacheDir=/private/tmp/aparapi-zinc-jdk11 -DargLine="-XX:+IgnoreUnrecognizedVMOptions" -Dtest=LongVariableDeclarationWithCastNoDebugInfoTest,FirstAssignInExpressionTest,MultipleAssignTest test
JAVA_HOME=/private/tmp/jdk-11 PATH=/private/tmp/apache-maven-3.9.11/bin:/private/tmp/jdk-11/bin:$PATH mvn -q -Dmaven.repo.local=/private/tmp/aparapi-m2 -DsecondaryCacheDir=/private/tmp/aparapi-zinc-jdk11 -DargLine="-XX:+IgnoreUnrecognizedVMOptions" -DskipTests package
```

I also ran the full test suite. It reaches 576 tests but fails three existing runtime tests in this environment while repeatedly reporting that the OpenCL native library/device is unavailable: `ArrayTest`, `AccessGetterSetterTest`, and `CallStaticFromAnonymousKernelTest`.

If the bounty is still active and BTC payment is available: `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`.