### PR TITLE
Include private superclass fields in kernel struct

### DIFF
--- a/src/main/java/com/aparapi/internal/model/Entrypoint.java
+++ b/src/main/java/com/aparapi/internal/model/Entrypoint.java
@@ -160,8 +160,7 @@ public class Entrypoint implements Cloneable {
       // while not found
       //  get its fields
       //  if found
-      //   if not private, done
-      //  if private, failure
+      //   if not static, done
       //  if not found, get next superclass
 
       Field field = null;
@@ -201,12 +200,12 @@ public class Entrypoint implements Cloneable {
          try {
             field = mySuper.getDeclaredField(_name);
             final int modifiers = field.getModifiers();
-            if ((Modifier.isStatic(modifiers) == false) && (Modifier.isPrivate(modifiers) == false)) {
+            if (Modifier.isStatic(modifiers) == false) {
                final Class<?> type = field.getType();
                if (logger.isLoggable(Level.FINE)) {
                   logger.fine("field type is " + type.getName());
                }
-               if (type.isPrimitive() || type.isArray()) {
+               if (type.isPrimitive() || type.isArray() || type.equals(AtomicInteger.class)) {
                   return field;
                }
                throw new ClassParseException(ClassParseException.TYPE.OBJECTFIELDREFERENCE);

--- a/src/test/java/com/aparapi/runtime/PrivateSuperclassFieldTest.java
+++ b/src/test/java/com/aparapi/runtime/PrivateSuperclassFieldTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016 - 2018 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.aparapi.runtime;
+
+import com.aparapi.Kernel;
+import com.aparapi.internal.model.ClassModel;
+import com.aparapi.internal.model.Entrypoint;
+import com.aparapi.internal.writer.KernelWriter;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertTrue;
+
+public class PrivateSuperclassFieldTest {
+
+    @Test
+    public void privateSuperclassFieldsAreIncludedInThisStruct() throws Exception {
+        final ClassModel classModel = ClassModel.createClassModel(ChildKernel.class);
+        final Entrypoint entrypoint = classModel.getEntrypoint("run", new ChildKernel());
+        final String opencl = KernelWriter.writeToString(entrypoint);
+
+        assertTrue(hasReferencedField(entrypoint, ParentKernel.class, "values"));
+        assertTrue(hasReferencedField(entrypoint, ParentKernel.class, "scale"));
+        assertTrue(opencl, opencl.contains("__global int *values;"));
+        assertTrue(opencl, opencl.contains("int scale;"));
+    }
+
+    private static boolean hasReferencedField(Entrypoint entrypoint, Class<?> declaringClass, String fieldName) {
+        for (final Field field : entrypoint.getReferencedFields()) {
+            if (field.getDeclaringClass().equals(declaringClass) && field.getName().equals(fieldName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public abstract static class ParentKernel extends Kernel {
+        private int[] values = new int[1];
+        private int scale = 7;
+
+        protected void updateValue(int id) {
+            values[id] = scale;
+        }
+    }
+
+    public static class ChildKernel extends ParentKernel {
+        @Override
+        public void run() {
+            updateValue(getGlobalId());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #15.

This updates kernel field discovery so non-static primitive, array, and AtomicInteger fields declared on a superclass are retained even when they are private. Those fields can be referenced from superclass methods that are part of the generated kernel call graph, so they need to be included in This_s.

A regression test covers private superclass fields being present both in the entrypoint referenced fields and in the emitted This_s struct.

Validation:
- git diff --check
- mvn -q -Dmaven.repo.local=/private/tmp/aparapi-m2 -DsecondaryCacheDir=/private/tmp/aparapi-zinc-jdk11 -DargLine="-XX:+IgnoreUnrecognizedVMOptions" -Dtest=PrivateSuperclassFieldTest,OverriddenKernelFieldTest,CallSuperTest test

BTC payout address: 39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ