### PR TITLE
Support break in loop code generation

### DIFF
--- a/src/main/java/com/aparapi/internal/instruction/ExpressionList.java
+++ b/src/main/java/com/aparapi/internal/instruction/ExpressionList.java
@@ -673,6 +673,26 @@ public class ExpressionList{
 
                     }
                 }
+                if (!handled && tail.isBranch() && tail.asBranch().isForwardUnconditional()
+                    && _instruction.isForwardConditionalBranchTarget()) {
+                    final Branch forwardGoto = tail.asBranch();
+                    final Instruction forwardTarget = forwardGoto.getTarget();
+                    final Instruction beforeForwardTarget = forwardTarget.getPrevPC();
+                    if (forwardTarget.isAfter(_instruction) && forwardTarget.isForwardConditionalBranchTarget()) {
+                        if (beforeForwardTarget != null && beforeForwardTarget.isBranch()
+                            && beforeForwardTarget.asBranch().isReverseUnconditional()) {
+                            final ConditionalBranch lastForwardConditional = _instruction.getForwardConditionalBranches().getLast();
+                            final BranchSet branchSet = lastForwardConditional.getOrCreateBranchSet();
+                            if (doesNotContainCompositeOrBranch(branchSet.getLast().getNextExpr(), forwardGoto)) {
+                                forwardGoto.setBreakOrContinue(true);
+                                branchSet.unhook();
+                                forwardGoto.unhook();
+                                addAsComposites(ByteCode.COMPOSITE_IF, branchSet.getFirst().getPrevExpr(), branchSet);
+                                handled = true;
+                            }
+                        }
+                    }
+                }
                 if (!handled && !tail.isForwardBranch() && _instruction.isForwardConditionalBranchTarget()) {
                     /**
                      * This an if(exp)

--- a/src/main/java/com/aparapi/internal/writer/BlockWriter.java
+++ b/src/main/java/com/aparapi/internal/writer/BlockWriter.java
@@ -80,6 +80,8 @@ public abstract class BlockWriter{
 
    public final static String arrayDimMangleSuffix = "__javaArrayDimension";
 
+   private final Stack<Instruction> breakTargets = new Stack<Instruction>();
+
    public abstract void write(String _string);
 
    public void writeln(String _string) {
@@ -207,11 +209,11 @@ public abstract class BlockWriter{
             if (!(delta instanceof CompositeInstruction)) {
                writeInstruction(delta);
                write(")");
-               writeBlock(blockStart, delta);
+               writeBreakableBlock(blockStart, delta, branchSet.getTarget());
             } else {
                write("){");
                in();
-               writeSequence(blockStart, delta);
+               writeBreakableSequence(blockStart, delta, branchSet.getTarget());
 
                newLine();
                writeSequence(delta, delta.getNextExpr());
@@ -229,7 +231,7 @@ public abstract class BlockWriter{
          final Instruction blockStart = writeConditional(branchSet);
          write(")");
          final Instruction lastGoto = instruction.getLastChild();
-         writeBlock(blockStart, lastGoto);
+         writeBreakableBlock(blockStart, lastGoto, branchSet.getTarget());
 
       } else if (instruction instanceof CompositeEmptyLoopInstruction) {
          newLine();
@@ -256,17 +258,18 @@ public abstract class BlockWriter{
          while (last.getPrevExpr().isBranch()) {
             last = last.getPrevExpr();
          }
-         writeConditional(instruction.getBranchSet(), true);
+         final BranchSet branchSet = instruction.getBranchSet();
+         writeConditional(branchSet, true);
          write("; ");
          final Instruction delta = last.getPrevExpr();
          if (!(delta instanceof CompositeInstruction)) {
             writeInstruction(delta);
             write(")");
-            writeBlock(topGoto.getNextExpr(), delta);
+            writeBreakableBlock(topGoto.getNextExpr(), delta, branchSet.getFallThrough());
          } else {
             write("){");
             in();
-            writeSequence(topGoto.getNextExpr(), delta);
+            writeBreakableSequence(topGoto.getNextExpr(), delta, branchSet.getFallThrough());
 
             newLine();
             writeSequence(delta, delta.getNextExpr());
@@ -281,7 +284,7 @@ public abstract class BlockWriter{
          write("do");
          Instruction blockStart = instruction.getFirstChild();
          Instruction blockEnd = instruction.getLastChild();
-         writeBlock(blockStart, blockEnd);
+         writeBreakableBlock(blockStart, blockEnd, ((CompositeInstruction) instruction).getBranchSet().getFallThrough());
          write("while(");
          writeConditional(((CompositeInstruction) instruction).getBranchSet(), true);
          write(");");
@@ -325,6 +328,42 @@ public abstract class BlockWriter{
       newLine();
 
       write("}");
+   }
+
+   private void writeBreakableBlock(Instruction first, Instruction last, Instruction breakTarget) throws CodeGenException {
+      pushBreakTarget(breakTarget);
+      try {
+         writeBlock(first, last);
+      } finally {
+         popBreakTarget();
+      }
+   }
+
+   private void writeBreakableSequence(Instruction first, Instruction last, Instruction breakTarget) throws CodeGenException {
+      pushBreakTarget(breakTarget);
+      try {
+         writeSequence(first, last);
+      } finally {
+         popBreakTarget();
+      }
+   }
+
+   private void pushBreakTarget(Instruction breakTarget) {
+      breakTargets.push(breakTarget);
+   }
+
+   private void popBreakTarget() {
+      breakTargets.pop();
+   }
+
+   private boolean isCurrentBreakTarget(Branch branch) {
+      if (breakTargets.isEmpty()) {
+         return false;
+      }
+
+      final Instruction breakTarget = breakTargets.peek();
+      final Instruction branchTarget = branch.getTarget();
+      return branchTarget == breakTarget || branchTarget.getStartPC() == breakTarget.getStartPC();
    }
 
    public Instruction writeConditional(BranchSet _branchSet) throws CodeGenException {
@@ -745,10 +784,13 @@ public abstract class BlockWriter{
       } else if (_instruction.getByteCode().equals(ByteCode.NONE)) {
          // we are done
       } else if (_instruction instanceof Branch) {
-          if(_instruction instanceof ConditionalBranch16)
+          final Branch branch = (Branch) _instruction;
+          if (isCurrentBreakTarget(branch)) {
+             write("break");
+          } else if(_instruction instanceof ConditionalBranch16)
             writeConditionalBranch16((ConditionalBranch16) _instruction, true);
           else
-            throw new CodeGenException(String.format("%s -> %04d", _instruction.getByteCode().toString().toLowerCase(), ((Branch) _instruction).getTarget().getThisPC()));
+            throw new CodeGenException(String.format("%s -> %04d", _instruction.getByteCode().toString().toLowerCase(), branch.getTarget().getThisPC()));
       } else if (_instruction instanceof I_POP) {
          //POP discarded void call return?
          writeInstruction(_instruction.getFirstChild());

--- a/src/test/java/com/aparapi/codegen/test/Break.java
+++ b/src/test/java/com/aparapi/codegen/test/Break.java
@@ -26,4 +26,3 @@ public class Break {
         }
     }
 }
-/**{Throws{ClassParseException}Throws}**/

--- a/src/test/java/com/aparapi/codegen/test/BreakTest.java
+++ b/src/test/java/com/aparapi/codegen/test/BreakTest.java
@@ -15,12 +15,37 @@
  */
 package com.aparapi.codegen.test;
 
-import com.aparapi.internal.exception.ClassParseException;
 import org.junit.Test;
 
 public class BreakTest extends com.aparapi.codegen.CodeGenJUnitBase {
-    private static final String[] expectedOpenCL = null;
-    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = ClassParseException.class;
+    private static final String[] expectedOpenCL = {
+    "typedef struct This_s{\n" +
+"\n" +
+" int passid;\n" +
+" }This;\n" +
+" int get_pass_id(This *this){\n" +
+" return this->passid;\n" +
+" }\n" +
+"\n" +
+" __kernel void run(\n" +
+" int passid\n" +
+" ){\n" +
+" This thisStruct;\n" +
+" This* this=&thisStruct;\n" +
+" this->passid = passid;\n" +
+" {\n" +
+" char pass = 0;\n" +
+" for (int i = 0; i<10; i++){\n" +
+" if (i==5){\n" +
+" break;\n" +
+" }\n" +
+" pass = 1;\n" +
+" }\n" +
+" return;\n" +
+" }\n" +
+" }\n" +
+" "};
+    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test
     public void BreakTest() {

--- a/src/test/java/com/aparapi/codegen/test/ForBreak.java
+++ b/src/test/java/com/aparapi/codegen/test/ForBreak.java
@@ -30,4 +30,3 @@ public class ForBreak {
 
     }
 }
-/**{Throws{ClassParseException}Throws}**/

--- a/src/test/java/com/aparapi/codegen/test/ForBreakTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ForBreakTest.java
@@ -15,12 +15,38 @@
  */
 package com.aparapi.codegen.test;
 
-import com.aparapi.internal.exception.ClassParseException;
 import org.junit.Test;
 
 public class ForBreakTest extends com.aparapi.codegen.CodeGenJUnitBase {
-    private static final String[] expectedOpenCL = null;
-    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = ClassParseException.class;
+    private static final String[] expectedOpenCL = {
+    "typedef struct This_s{\n" +
+"\n" +
+" int passid;\n" +
+" }This;\n" +
+" int get_pass_id(This *this){\n" +
+" return this->passid;\n" +
+" }\n" +
+"\n" +
+" __kernel void run(\n" +
+" int passid\n" +
+" ){\n" +
+" This thisStruct;\n" +
+" This* this=&thisStruct;\n" +
+" this->passid = passid;\n" +
+" {\n" +
+" char pass = 0;\n" +
+" for (int i = 0; i>2 && i<10; i++){\n" +
+" pass = 0;\n" +
+" if ((i==5 || i==6) && i==5){\n" +
+" pass = 1;\n" +
+" break;\n" +
+" }\n" +
+" }\n" +
+" return;\n" +
+" }\n" +
+" }\n" +
+" "};
+    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test
     public void ForBreakTest() {


### PR DESCRIPTION
Fixes #93.

Summary:
- Fold javac if-then-goto loop break bytecode into an if composite before loop folding.
- Track active loop break targets while writing loop bodies and emit break for matching forward gotos.
- Update Break and ForBreak codegen tests to expect generated OpenCL instead of ClassParseException.

Validation:
- mvn -q -Dmaven.repo.local=/private/tmp/aparapi-m2 -DsecondaryCacheDir=/private/tmp/aparapi-zinc-jdk11 -DargLine="-XX:+IgnoreUnrecognizedVMOptions" -Dtest=BreakTest,ForBreakTest,ContinueTest,MultiContinueTest test
- mvn -q -Dmaven.repo.local=/private/tmp/aparapi-m2 -DsecondaryCacheDir=/private/tmp/aparapi-zinc-jdk11 -DargLine="-XX:+IgnoreUnrecognizedVMOptions" -Dtest=com.aparapi.codegen.test.*Test,!com.aparapi.codegen.test.If_While_Else_WhileTest test
- mvn -q -Dmaven.repo.local=/private/tmp/aparapi-m2 -DsecondaryCacheDir=/private/tmp/aparapi-zinc-jdk11 -DargLine="-XX:+IgnoreUnrecognizedVMOptions" -DskipTests package
- git diff --check

Note: If_While_Else_WhileTest fails on clean HEAD in this environment with NullPointerException, so I excluded only that known failing class from the broad codegen run.
