### PR TITLE
Add syncThreads barrier alias

### DIFF
--- a/src/main/java/com/aparapi/Kernel.java
+++ b/src/main/java/com/aparapi/Kernel.java
@@ -2520,6 +2520,20 @@ public abstract class Kernel implements Cloneable {
 	   kernelState.awaitOnLocalBarrier();
    }
 
+   /**
+    * Wait for all kernels in the current work group to rendezvous at this call before continuing execution.
+    * <p>
+    * This is a convenience alias for {@link #localGlobalBarrier()} intended for callers looking for a CUDA-style
+    * thread synchronization primitive.
+    *
+    * @annotion Experimental
+    */
+   @OpenCLDelegate
+   @Experimental
+   protected final void syncThreads() {
+	   kernelState.awaitOnLocalBarrier();
+   }
+
    @OpenCLMapping(mapTo = "hypot")
    protected float hypot(final float a, final float b) {
       return (float) Math.hypot(a, b);

--- a/src/main/java/com/aparapi/internal/writer/KernelWriter.java
+++ b/src/main/java/com/aparapi/internal/writer/KernelWriter.java
@@ -162,6 +162,8 @@ public abstract class KernelWriter extends BlockWriter{
       javaToCLIdentifierMap.put("globalBarrier()V", "barrier(CLK_GLOBAL_MEM_FENCE)");
       
       javaToCLIdentifierMap.put("localGlobalBarrier()V", "barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE)");
+
+      javaToCLIdentifierMap.put("syncThreads()V", "barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE)");
    }
 
    /**

--- a/src/test/java/com/aparapi/codegen/test/CallSyncThreads.java
+++ b/src/test/java/com/aparapi/codegen/test/CallSyncThreads.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2016 - 2018 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.aparapi.codegen.test;
+
+import com.aparapi.Kernel;
+
+public class CallSyncThreads extends Kernel {
+   @Override
+   public void run() {
+      syncThreads();
+   }
+}
+
+/**{OpenCL{
+
+ typedef struct This_s{
+ int passid;
+ }This;
+ int get_pass_id(This *this){
+ return this->passid;
+ }
+ __kernel void run(
+ int passid
+ ){
+ This thisStruct;
+ This* this=&thisStruct;
+ this->passid = passid;
+ {
+ barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE);
+ return;
+ }
+ }
+ }OpenCL}**/

--- a/src/test/java/com/aparapi/codegen/test/CallSyncThreadsTest.java
+++ b/src/test/java/com/aparapi/codegen/test/CallSyncThreadsTest.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016 - 2018 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.aparapi.codegen.test;
+
+import org.junit.Test;
+
+public class CallSyncThreadsTest extends com.aparapi.codegen.CodeGenJUnitBase {
+   private static final String[] expectedOpenCL = {"typedef struct This_s{\n" +
+" int passid;\n" +
+" }This;\n" +
+" int get_pass_id(This *this){\n" +
+" return this->passid;\n" +
+" }\n" +
+" __kernel void run(\n" +
+" int passid\n" +
+" ){\n" +
+" This thisStruct;\n" +
+" This* this=&thisStruct;\n" +
+" this->passid = passid;\n" +
+" {\n" +
+" barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE);\n" +
+" return;\n" +
+" }\n" +
+" }"};
+   private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
+
+   @Test
+   public void CallSyncThreadsTest() {
+      test(com.aparapi.codegen.test.CallSyncThreads.class, expectedException, expectedOpenCL);
+   }
+
+   @Test
+   public void CallSyncThreadsTestWorksWithCaching() {
+      test(com.aparapi.codegen.test.CallSyncThreads.class, expectedException, expectedOpenCL);
+   }
+}

--- a/src/test/java/com/aparapi/runtime/SyncThreadsSupportTest.java
+++ b/src/test/java/com/aparapi/runtime/SyncThreadsSupportTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2016 - 2018 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.aparapi.runtime;
+
+import com.aparapi.Kernel;
+import com.aparapi.Range;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class SyncThreadsSupportTest {
+   @Test
+   @SuppressWarnings("deprecation")
+   public void syncThreadsWaitsForAllLocalWorkItems() {
+      final int[] shared = new int[2];
+      final int[] result = new int[2];
+      Kernel kernel = new Kernel() {
+         @Override
+         public void run() {
+            int id = getLocalId();
+            shared[id] = id + 1;
+            syncThreads();
+            result[id] = shared[1 - id];
+         }
+      };
+      kernel.setExecutionMode(Kernel.EXECUTION_MODE.JTP);
+
+      kernel.execute(Range.create(2, 2));
+
+      assertArrayEquals(new int[] { 2, 1 }, result);
+   }
+}


### PR DESCRIPTION
Adds a CUDA-style `syncThreads()` helper for synchronizing all work-items in the current work group.

Changes:
- Adds `Kernel.syncThreads()` as a convenience alias for `localGlobalBarrier()` semantics
- Maps `syncThreads()` to `barrier(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE)` in generated OpenCL
- Adds codegen coverage for the generated barrier call
- Adds a JTP runtime test showing local work-items wait before reading each other's writes

/claim #40

Testing:
- `git diff --check`
- Not run: Maven/JUnit tests because this Codex environment has no Java runtime or `mvn` installed.