### PR TITLE
Fix returning newly instantiated arrays

### DIFF
--- a/src/main/java/com/aparapi/internal/writer/BlockWriter.java
+++ b/src/main/java/com/aparapi/internal/writer/BlockWriter.java
@@ -397,14 +397,10 @@ public abstract class BlockWriter{
 
       } else if (_instruction instanceof I_NEWARRAY) {
           if (_instruction.getParentExpr() instanceof Return) {
-              throw new CodeGenException("'newarray' is not allowed after 'return'");
+              throw new CodeGenException("'newarray' must be emitted as a local before 'return'");
           }
 
-          for (Instruction operand = _instruction.getFirstChild(); operand != null; operand = operand.getNextExpr()) {
-              write("[");
-              writeInstruction(operand);
-              write("]");
-          }
+          writeNewArrayDimensions((I_NEWARRAY) _instruction);
 
       } else if (_instruction instanceof AssignToLocalVariable) {
          final AssignToLocalVariable assignToLocalVariable = (AssignToLocalVariable) _instruction;
@@ -632,11 +628,24 @@ public abstract class BlockWriter{
       } else if (_instruction instanceof Return) {
 
          final Return ret = (Return) _instruction;
-         write("return");
-         if (ret.getStackConsumeCount() > 0) {
-            write("(");
-            writeInstruction(ret.getFirstChild());
+         if (ret.getFirstChild() instanceof I_NEWARRAY) {
+            final I_NEWARRAY newArray = (I_NEWARRAY) ret.getFirstChild();
+            final String returnArray = "returnArray" + newArray.getThisPC();
+            write(convertType(getNewArrayDescriptor(newArray), true, true));
+            write(returnArray);
+            writeNewArrayDimensions(newArray);
+            write(";");
+            newLine();
+            write("return(");
+            write(returnArray);
             write(")");
+         } else {
+            write("return");
+            if (ret.getStackConsumeCount() > 0) {
+               write("(");
+               writeInstruction(ret.getFirstChild());
+               write(")");
+            }
          }
 
       } else if (_instruction instanceof MethodCall) {
@@ -756,6 +765,37 @@ public abstract class BlockWriter{
          throw new CodeGenException(String.format("%s", _instruction.getByteCode().toString().toLowerCase()));
       }
 
+   }
+
+   private void writeNewArrayDimensions(I_NEWARRAY newArray) throws CodeGenException {
+      for (Instruction operand = newArray.getFirstChild(); operand != null; operand = operand.getNextExpr()) {
+         write("[");
+         writeInstruction(operand);
+         write("]");
+      }
+   }
+
+   private String getNewArrayDescriptor(I_NEWARRAY newArray) throws CodeGenException {
+      switch (newArray.getType()) {
+         case 4:
+            return "[Z";
+         case 5:
+            return "[C";
+         case 6:
+            return "[F";
+         case 7:
+            return "[D";
+         case 8:
+            return "[B";
+         case 9:
+            return "[S";
+         case 10:
+            return "[I";
+         case 11:
+            return "[J";
+         default:
+            throw new CodeGenException("Unsupported newarray type " + newArray.getType());
+      }
    }
 
    private boolean isNeedParenthesis(Instruction instruction){

--- a/src/main/java/com/aparapi/internal/writer/BlockWriter.java
+++ b/src/main/java/com/aparapi/internal/writer/BlockWriter.java
@@ -396,10 +396,6 @@ public abstract class BlockWriter{
           writeComposite((CompositeInstruction) _instruction);
 
       } else if (_instruction instanceof I_NEWARRAY) {
-          if (_instruction.getParentExpr() instanceof Return) {
-              throw new CodeGenException("'newarray' must be emitted as a local before 'return'");
-          }
-
           writeNewArrayDimensions((I_NEWARRAY) _instruction);
 
       } else if (_instruction instanceof AssignToLocalVariable) {
@@ -630,22 +626,22 @@ public abstract class BlockWriter{
          final Return ret = (Return) _instruction;
          if (ret.getFirstChild() instanceof I_NEWARRAY) {
             final I_NEWARRAY newArray = (I_NEWARRAY) ret.getFirstChild();
-            final String returnArray = "returnArray" + newArray.getThisPC();
-            write(convertType(getNewArrayDescriptor(newArray), true, true));
-            write(returnArray);
+            final String returnArrayName = "returnArray" + ret.getThisPC();
+            write(convertType(ret.getMethod().getReturnType(), true, true));
+            write(returnArrayName);
             writeNewArrayDimensions(newArray);
             write(";");
             newLine();
             write("return(");
-            write(returnArray);
+            write(returnArrayName);
             write(")");
-         } else {
-            write("return");
-            if (ret.getStackConsumeCount() > 0) {
-               write("(");
-               writeInstruction(ret.getFirstChild());
-               write(")");
-            }
+            return;
+         }
+         write("return");
+         if (ret.getStackConsumeCount() > 0) {
+            write("(");
+            writeInstruction(ret.getFirstChild());
+            write(")");
          }
 
       } else if (_instruction instanceof MethodCall) {
@@ -772,29 +768,6 @@ public abstract class BlockWriter{
          write("[");
          writeInstruction(operand);
          write("]");
-      }
-   }
-
-   private String getNewArrayDescriptor(I_NEWARRAY newArray) throws CodeGenException {
-      switch (newArray.getType()) {
-         case 4:
-            return "[Z";
-         case 5:
-            return "[C";
-         case 6:
-            return "[F";
-         case 7:
-            return "[D";
-         case 8:
-            return "[B";
-         case 9:
-            return "[S";
-         case 10:
-            return "[I";
-         case 11:
-            return "[J";
-         default:
-            throw new CodeGenException("Unsupported newarray type " + newArray.getType());
       }
    }
 

--- a/src/test/java/com/aparapi/codegen/test/ReturnArrayNewTestSupport.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnArrayNewTestSupport.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016 - 2018 Syncleus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.aparapi.codegen.test;
+
+final class ReturnArrayNewTestSupport {
+
+    private ReturnArrayNewTestSupport() {
+    }
+
+    static String[] expectedOpenCL(String openCLType, String className, String methodName) {
+        String qualifiedMethodName = "com_aparapi_codegen_test_" + className + "__" + methodName;
+        return new String[] {
+            "typedef struct This_s{\n"
+                + "   int passid;\n"
+                + "}This;\n"
+                + "int get_pass_id(This *this){\n"
+                + "   return this->passid;\n"
+                + "}\n"
+                + " __global " + openCLType + "* " + qualifiedMethodName + "(This *this){\n"
+                + "   " + openCLType + " returnArray5[1024];\n"
+                + "   return(returnArray5);\n"
+                + "}\n"
+                + "__kernel void run(\n"
+                + "   int passid\n"
+                + "){\n"
+                + "   This thisStruct;\n"
+                + "   This* this=&thisStruct;\n"
+                + "   this->passid = passid;\n"
+                + "   {\n"
+                + "      " + qualifiedMethodName + "(this);\n"
+                + "      return;\n"
+                + "   }\n"
+                + "}"
+        };
+    }
+}

--- a/src/test/java/com/aparapi/codegen/test/ReturnBooleanNewArray.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnBooleanNewArray.java
@@ -26,4 +26,27 @@ public class ReturnBooleanNewArray {
         returnBooleanNewArray();
     }
 }
-/**{Throws{CodeGenException}Throws}**/
+/**{OpenCL{
+ typedef struct This_s{
+ int passid;
+ }This;
+ int get_pass_id(This *this){
+ return this->passid;
+ }
+ __global char* com_aparapi_codegen_test_ReturnBooleanNewArray__returnBooleanNewArray(This *this){
+ char returnArray5[1024];
+ return(returnArray5);
+ }
+ __kernel void run(
+ int passid
+ ){
+ This thisStruct;
+ This* this=&thisStruct;
+ this->passid = passid;
+ {
+ com_aparapi_codegen_test_ReturnBooleanNewArray__returnBooleanNewArray(this);
+ return;
+ }
+ }
+
+ }OpenCL}**/

--- a/src/test/java/com/aparapi/codegen/test/ReturnBooleanNewArrayTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnBooleanNewArrayTest.java
@@ -15,13 +15,13 @@
  */
 package com.aparapi.codegen.test;
 
-import com.aparapi.internal.exception.CodeGenException;
 import org.junit.Test;
 
 public class ReturnBooleanNewArrayTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = null;
-    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = CodeGenException.class;
+    private static final String[] expectedOpenCL = ReturnArrayNewTestSupport.expectedOpenCL("char",
+            "ReturnBooleanNewArray", "returnBooleanNewArray");
+    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test
     public void ReturnBooleanNewArrayTest() {

--- a/src/test/java/com/aparapi/codegen/test/ReturnByteArrayNew.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnByteArrayNew.java
@@ -25,4 +25,27 @@ public class ReturnByteArrayNew {
         returnByteArrayNew();
     }
 }
-/**{Throws{CodeGenException}Throws}**/
+/**{OpenCL{
+ typedef struct This_s{
+ int passid;
+ }This;
+ int get_pass_id(This *this){
+ return this->passid;
+ }
+ __global char* com_aparapi_codegen_test_ReturnByteArrayNew__returnByteArrayNew(This *this){
+ char returnArray5[1024];
+ return(returnArray5);
+ }
+ __kernel void run(
+ int passid
+ ){
+ This thisStruct;
+ This* this=&thisStruct;
+ this->passid = passid;
+ {
+ com_aparapi_codegen_test_ReturnByteArrayNew__returnByteArrayNew(this);
+ return;
+ }
+ }
+
+ }OpenCL}**/

--- a/src/test/java/com/aparapi/codegen/test/ReturnByteArrayNewTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnByteArrayNewTest.java
@@ -19,29 +19,8 @@ import org.junit.Test;
 
 public class ReturnByteArrayNewTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = {
-        "typedef struct This_s{\n"
-            + "   int passid;\n"
-            + "}This;\n"
-            + "int get_pass_id(This *this){\n"
-            + "   return this->passid;\n"
-            + "}\n"
-            + " __global char* com_aparapi_codegen_test_ReturnByteArrayNew__returnByteArrayNew(This *this){\n"
-            + "   char returnArray3[1024];\n"
-            + "   return(returnArray3);\n"
-            + "}\n"
-            + "__kernel void run(\n"
-            + "   int passid\n"
-            + "){\n"
-            + "   This thisStruct;\n"
-            + "   This* this=&thisStruct;\n"
-            + "   this->passid = passid;\n"
-            + "   {\n"
-            + "      com_aparapi_codegen_test_ReturnByteArrayNew__returnByteArrayNew(this);\n"
-            + "      return;\n"
-            + "   }\n"
-            + "}"
-    };
+    private static final String[] expectedOpenCL = ReturnArrayNewTestSupport.expectedOpenCL("char",
+            "ReturnByteArrayNew", "returnByteArrayNew");
     private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test

--- a/src/test/java/com/aparapi/codegen/test/ReturnByteArrayNewTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnByteArrayNewTest.java
@@ -15,20 +15,40 @@
  */
 package com.aparapi.codegen.test;
 
-import com.aparapi.internal.exception.CodeGenException;
 import org.junit.Test;
 
 public class ReturnByteArrayNewTest extends com.aparapi.codegen.CodeGenJUnitBase {
-    private static final String[] expectedOpenCL = null;
-    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = CodeGenException.class;
 
-    
+    private static final String[] expectedOpenCL = {
+        "typedef struct This_s{\n"
+            + "   int passid;\n"
+            + "}This;\n"
+            + "int get_pass_id(This *this){\n"
+            + "   return this->passid;\n"
+            + "}\n"
+            + " __global char* com_aparapi_codegen_test_ReturnByteArrayNew__returnByteArrayNew(This *this){\n"
+            + "   char returnArray3[1024];\n"
+            + "   return(returnArray3);\n"
+            + "}\n"
+            + "__kernel void run(\n"
+            + "   int passid\n"
+            + "){\n"
+            + "   This thisStruct;\n"
+            + "   This* this=&thisStruct;\n"
+            + "   this->passid = passid;\n"
+            + "   {\n"
+            + "      com_aparapi_codegen_test_ReturnByteArrayNew__returnByteArrayNew(this);\n"
+            + "      return;\n"
+            + "   }\n"
+            + "}"
+    };
+    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
+
     @Test
     public void ReturnByteArrayNewTest() {
         test(com.aparapi.codegen.test.ReturnByteArrayNew.class, expectedException, expectedOpenCL);
     }
 
-    
     @Test
     public void ReturnByteArrayNewTestWorksWithCaching() {
         test(com.aparapi.codegen.test.ReturnByteArrayNew.class, expectedException, expectedOpenCL);

--- a/src/test/java/com/aparapi/codegen/test/ReturnDoubleArrayNew.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnDoubleArrayNew.java
@@ -25,4 +25,27 @@ public class ReturnDoubleArrayNew {
         returnDoubleArrayNew();
     }
 }
-/**{Throws{CodeGenException}Throws}**/
+/**{OpenCL{
+ typedef struct This_s{
+ int passid;
+ }This;
+ int get_pass_id(This *this){
+ return this->passid;
+ }
+ __global double* com_aparapi_codegen_test_ReturnDoubleArrayNew__returnDoubleArrayNew(This *this){
+ double returnArray5[1024];
+ return(returnArray5);
+ }
+ __kernel void run(
+ int passid
+ ){
+ This thisStruct;
+ This* this=&thisStruct;
+ this->passid = passid;
+ {
+ com_aparapi_codegen_test_ReturnDoubleArrayNew__returnDoubleArrayNew(this);
+ return;
+ }
+ }
+
+ }OpenCL}**/

--- a/src/test/java/com/aparapi/codegen/test/ReturnDoubleArrayNewTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnDoubleArrayNewTest.java
@@ -15,13 +15,34 @@
  */
 package com.aparapi.codegen.test;
 
-import com.aparapi.internal.exception.CodeGenException;
 import org.junit.Test;
 
 public class ReturnDoubleArrayNewTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = null;
-    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = CodeGenException.class;
+    private static final String[] expectedOpenCL = {
+        "typedef struct This_s{\n"
+            + "   int passid;\n"
+            + "}This;\n"
+            + "int get_pass_id(This *this){\n"
+            + "   return this->passid;\n"
+            + "}\n"
+            + " __global double* com_aparapi_codegen_test_ReturnDoubleArrayNew__returnDoubleArrayNew(This *this){\n"
+            + "   double returnArray3[1024];\n"
+            + "   return(returnArray3);\n"
+            + "}\n"
+            + "__kernel void run(\n"
+            + "   int passid\n"
+            + "){\n"
+            + "   This thisStruct;\n"
+            + "   This* this=&thisStruct;\n"
+            + "   this->passid = passid;\n"
+            + "   {\n"
+            + "      com_aparapi_codegen_test_ReturnDoubleArrayNew__returnDoubleArrayNew(this);\n"
+            + "      return;\n"
+            + "   }\n"
+            + "}"
+    };
+    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test
     public void ReturnDoubleArrayNewTest() {

--- a/src/test/java/com/aparapi/codegen/test/ReturnDoubleArrayNewTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnDoubleArrayNewTest.java
@@ -19,29 +19,8 @@ import org.junit.Test;
 
 public class ReturnDoubleArrayNewTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = {
-        "typedef struct This_s{\n"
-            + "   int passid;\n"
-            + "}This;\n"
-            + "int get_pass_id(This *this){\n"
-            + "   return this->passid;\n"
-            + "}\n"
-            + " __global double* com_aparapi_codegen_test_ReturnDoubleArrayNew__returnDoubleArrayNew(This *this){\n"
-            + "   double returnArray3[1024];\n"
-            + "   return(returnArray3);\n"
-            + "}\n"
-            + "__kernel void run(\n"
-            + "   int passid\n"
-            + "){\n"
-            + "   This thisStruct;\n"
-            + "   This* this=&thisStruct;\n"
-            + "   this->passid = passid;\n"
-            + "   {\n"
-            + "      com_aparapi_codegen_test_ReturnDoubleArrayNew__returnDoubleArrayNew(this);\n"
-            + "      return;\n"
-            + "   }\n"
-            + "}"
-    };
+    private static final String[] expectedOpenCL = ReturnArrayNewTestSupport.expectedOpenCL("double",
+            "ReturnDoubleArrayNew", "returnDoubleArrayNew");
     private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test

--- a/src/test/java/com/aparapi/codegen/test/ReturnFloatArrayNew.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnFloatArrayNew.java
@@ -25,4 +25,27 @@ public class ReturnFloatArrayNew {
         returnFloatArrayNew();
     }
 }
-/**{Throws{CodeGenException}Throws}**/
+/**{OpenCL{
+ typedef struct This_s{
+ int passid;
+ }This;
+ int get_pass_id(This *this){
+ return this->passid;
+ }
+ __global float* com_aparapi_codegen_test_ReturnFloatArrayNew__returnFloatArrayNew(This *this){
+ float returnArray5[1024];
+ return(returnArray5);
+ }
+ __kernel void run(
+ int passid
+ ){
+ This thisStruct;
+ This* this=&thisStruct;
+ this->passid = passid;
+ {
+ com_aparapi_codegen_test_ReturnFloatArrayNew__returnFloatArrayNew(this);
+ return;
+ }
+ }
+
+ }OpenCL}**/

--- a/src/test/java/com/aparapi/codegen/test/ReturnFloatArrayNewTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnFloatArrayNewTest.java
@@ -15,13 +15,34 @@
  */
 package com.aparapi.codegen.test;
 
-import com.aparapi.internal.exception.CodeGenException;
 import org.junit.Test;
 
 public class ReturnFloatArrayNewTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = null;
-    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = CodeGenException.class;
+    private static final String[] expectedOpenCL = {
+        "typedef struct This_s{\n"
+            + "   int passid;\n"
+            + "}This;\n"
+            + "int get_pass_id(This *this){\n"
+            + "   return this->passid;\n"
+            + "}\n"
+            + " __global float* com_aparapi_codegen_test_ReturnFloatArrayNew__returnFloatArrayNew(This *this){\n"
+            + "   float returnArray3[1024];\n"
+            + "   return(returnArray3);\n"
+            + "}\n"
+            + "__kernel void run(\n"
+            + "   int passid\n"
+            + "){\n"
+            + "   This thisStruct;\n"
+            + "   This* this=&thisStruct;\n"
+            + "   this->passid = passid;\n"
+            + "   {\n"
+            + "      com_aparapi_codegen_test_ReturnFloatArrayNew__returnFloatArrayNew(this);\n"
+            + "      return;\n"
+            + "   }\n"
+            + "}"
+    };
+    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test
     public void ReturnFloatArrayNewTest() {

--- a/src/test/java/com/aparapi/codegen/test/ReturnFloatArrayNewTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnFloatArrayNewTest.java
@@ -19,29 +19,8 @@ import org.junit.Test;
 
 public class ReturnFloatArrayNewTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = {
-        "typedef struct This_s{\n"
-            + "   int passid;\n"
-            + "}This;\n"
-            + "int get_pass_id(This *this){\n"
-            + "   return this->passid;\n"
-            + "}\n"
-            + " __global float* com_aparapi_codegen_test_ReturnFloatArrayNew__returnFloatArrayNew(This *this){\n"
-            + "   float returnArray3[1024];\n"
-            + "   return(returnArray3);\n"
-            + "}\n"
-            + "__kernel void run(\n"
-            + "   int passid\n"
-            + "){\n"
-            + "   This thisStruct;\n"
-            + "   This* this=&thisStruct;\n"
-            + "   this->passid = passid;\n"
-            + "   {\n"
-            + "      com_aparapi_codegen_test_ReturnFloatArrayNew__returnFloatArrayNew(this);\n"
-            + "      return;\n"
-            + "   }\n"
-            + "}"
-    };
+    private static final String[] expectedOpenCL = ReturnArrayNewTestSupport.expectedOpenCL("float",
+            "ReturnFloatArrayNew", "returnFloatArrayNew");
     private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test

--- a/src/test/java/com/aparapi/codegen/test/ReturnIntArrayNew.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnIntArrayNew.java
@@ -25,4 +25,27 @@ public class ReturnIntArrayNew {
         returnIntArrayNew();
     }
 }
-/**{Throws{CodeGenException}Throws}**/
+/**{OpenCL{
+ typedef struct This_s{
+ int passid;
+ }This;
+ int get_pass_id(This *this){
+ return this->passid;
+ }
+ __global int* com_aparapi_codegen_test_ReturnIntArrayNew__returnIntArrayNew(This *this){
+ int returnArray5[1024];
+ return(returnArray5);
+ }
+ __kernel void run(
+ int passid
+ ){
+ This thisStruct;
+ This* this=&thisStruct;
+ this->passid = passid;
+ {
+ com_aparapi_codegen_test_ReturnIntArrayNew__returnIntArrayNew(this);
+ return;
+ }
+ }
+
+ }OpenCL}**/

--- a/src/test/java/com/aparapi/codegen/test/ReturnIntArrayNewTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnIntArrayNewTest.java
@@ -19,29 +19,8 @@ import org.junit.Test;
 
 public class ReturnIntArrayNewTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = {
-        "typedef struct This_s{\n"
-            + "   int passid;\n"
-            + "}This;\n"
-            + "int get_pass_id(This *this){\n"
-            + "   return this->passid;\n"
-            + "}\n"
-            + " __global int* com_aparapi_codegen_test_ReturnIntArrayNew__returnIntArrayNew(This *this){\n"
-            + "   int returnArray3[1024];\n"
-            + "   return(returnArray3);\n"
-            + "}\n"
-            + "__kernel void run(\n"
-            + "   int passid\n"
-            + "){\n"
-            + "   This thisStruct;\n"
-            + "   This* this=&thisStruct;\n"
-            + "   this->passid = passid;\n"
-            + "   {\n"
-            + "      com_aparapi_codegen_test_ReturnIntArrayNew__returnIntArrayNew(this);\n"
-            + "      return;\n"
-            + "   }\n"
-            + "}"
-    };
+    private static final String[] expectedOpenCL = ReturnArrayNewTestSupport.expectedOpenCL("int",
+            "ReturnIntArrayNew", "returnIntArrayNew");
     private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test

--- a/src/test/java/com/aparapi/codegen/test/ReturnIntArrayNewTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnIntArrayNewTest.java
@@ -15,13 +15,34 @@
  */
 package com.aparapi.codegen.test;
 
-import com.aparapi.internal.exception.CodeGenException;
 import org.junit.Test;
 
 public class ReturnIntArrayNewTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = null;
-    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = CodeGenException.class;
+    private static final String[] expectedOpenCL = {
+        "typedef struct This_s{\n"
+            + "   int passid;\n"
+            + "}This;\n"
+            + "int get_pass_id(This *this){\n"
+            + "   return this->passid;\n"
+            + "}\n"
+            + " __global int* com_aparapi_codegen_test_ReturnIntArrayNew__returnIntArrayNew(This *this){\n"
+            + "   int returnArray3[1024];\n"
+            + "   return(returnArray3);\n"
+            + "}\n"
+            + "__kernel void run(\n"
+            + "   int passid\n"
+            + "){\n"
+            + "   This thisStruct;\n"
+            + "   This* this=&thisStruct;\n"
+            + "   this->passid = passid;\n"
+            + "   {\n"
+            + "      com_aparapi_codegen_test_ReturnIntArrayNew__returnIntArrayNew(this);\n"
+            + "      return;\n"
+            + "   }\n"
+            + "}"
+    };
+    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test
     public void ReturnIntArrayNewTest() {

--- a/src/test/java/com/aparapi/codegen/test/ReturnLongArrayNew.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnLongArrayNew.java
@@ -25,4 +25,27 @@ public class ReturnLongArrayNew {
         returnLongArrayNew();
     }
 }
-/**{Throws{CodeGenException}Throws}**/
+/**{OpenCL{
+ typedef struct This_s{
+ int passid;
+ }This;
+ int get_pass_id(This *this){
+ return this->passid;
+ }
+ __global long* com_aparapi_codegen_test_ReturnLongArrayNew__returnLongArrayNew(This *this){
+ long returnArray5[1024];
+ return(returnArray5);
+ }
+ __kernel void run(
+ int passid
+ ){
+ This thisStruct;
+ This* this=&thisStruct;
+ this->passid = passid;
+ {
+ com_aparapi_codegen_test_ReturnLongArrayNew__returnLongArrayNew(this);
+ return;
+ }
+ }
+
+ }OpenCL}**/

--- a/src/test/java/com/aparapi/codegen/test/ReturnLongArrayNewTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnLongArrayNewTest.java
@@ -15,13 +15,34 @@
  */
 package com.aparapi.codegen.test;
 
-import com.aparapi.internal.exception.CodeGenException;
 import org.junit.Test;
 
 public class ReturnLongArrayNewTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = null;
-    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = CodeGenException.class;
+    private static final String[] expectedOpenCL = {
+        "typedef struct This_s{\n"
+            + "   int passid;\n"
+            + "}This;\n"
+            + "int get_pass_id(This *this){\n"
+            + "   return this->passid;\n"
+            + "}\n"
+            + " __global long* com_aparapi_codegen_test_ReturnLongArrayNew__returnLongArrayNew(This *this){\n"
+            + "   long returnArray3[1024];\n"
+            + "   return(returnArray3);\n"
+            + "}\n"
+            + "__kernel void run(\n"
+            + "   int passid\n"
+            + "){\n"
+            + "   This thisStruct;\n"
+            + "   This* this=&thisStruct;\n"
+            + "   this->passid = passid;\n"
+            + "   {\n"
+            + "      com_aparapi_codegen_test_ReturnLongArrayNew__returnLongArrayNew(this);\n"
+            + "      return;\n"
+            + "   }\n"
+            + "}"
+    };
+    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test
     public void ReturnLongArrayNewTest() {

--- a/src/test/java/com/aparapi/codegen/test/ReturnLongArrayNewTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnLongArrayNewTest.java
@@ -19,29 +19,8 @@ import org.junit.Test;
 
 public class ReturnLongArrayNewTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = {
-        "typedef struct This_s{\n"
-            + "   int passid;\n"
-            + "}This;\n"
-            + "int get_pass_id(This *this){\n"
-            + "   return this->passid;\n"
-            + "}\n"
-            + " __global long* com_aparapi_codegen_test_ReturnLongArrayNew__returnLongArrayNew(This *this){\n"
-            + "   long returnArray3[1024];\n"
-            + "   return(returnArray3);\n"
-            + "}\n"
-            + "__kernel void run(\n"
-            + "   int passid\n"
-            + "){\n"
-            + "   This thisStruct;\n"
-            + "   This* this=&thisStruct;\n"
-            + "   this->passid = passid;\n"
-            + "   {\n"
-            + "      com_aparapi_codegen_test_ReturnLongArrayNew__returnLongArrayNew(this);\n"
-            + "      return;\n"
-            + "   }\n"
-            + "}"
-    };
+    private static final String[] expectedOpenCL = ReturnArrayNewTestSupport.expectedOpenCL("long",
+            "ReturnLongArrayNew", "returnLongArrayNew");
     private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test

--- a/src/test/java/com/aparapi/codegen/test/ReturnShortArrayNew.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnShortArrayNew.java
@@ -25,4 +25,27 @@ public class ReturnShortArrayNew {
         returnShortArrayNew();
     }
 }
-/**{Throws{CodeGenException}Throws}**/
+/**{OpenCL{
+ typedef struct This_s{
+ int passid;
+ }This;
+ int get_pass_id(This *this){
+ return this->passid;
+ }
+ __global short* com_aparapi_codegen_test_ReturnShortArrayNew__returnShortArrayNew(This *this){
+ short returnArray5[1024];
+ return(returnArray5);
+ }
+ __kernel void run(
+ int passid
+ ){
+ This thisStruct;
+ This* this=&thisStruct;
+ this->passid = passid;
+ {
+ com_aparapi_codegen_test_ReturnShortArrayNew__returnShortArrayNew(this);
+ return;
+ }
+ }
+
+ }OpenCL}**/

--- a/src/test/java/com/aparapi/codegen/test/ReturnShortArrayNewTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnShortArrayNewTest.java
@@ -19,29 +19,8 @@ import org.junit.Test;
 
 public class ReturnShortArrayNewTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = {
-        "typedef struct This_s{\n"
-            + "   int passid;\n"
-            + "}This;\n"
-            + "int get_pass_id(This *this){\n"
-            + "   return this->passid;\n"
-            + "}\n"
-            + " __global short* com_aparapi_codegen_test_ReturnShortArrayNew__returnShortArrayNew(This *this){\n"
-            + "   short returnArray3[1024];\n"
-            + "   return(returnArray3);\n"
-            + "}\n"
-            + "__kernel void run(\n"
-            + "   int passid\n"
-            + "){\n"
-            + "   This thisStruct;\n"
-            + "   This* this=&thisStruct;\n"
-            + "   this->passid = passid;\n"
-            + "   {\n"
-            + "      com_aparapi_codegen_test_ReturnShortArrayNew__returnShortArrayNew(this);\n"
-            + "      return;\n"
-            + "   }\n"
-            + "}"
-    };
+    private static final String[] expectedOpenCL = ReturnArrayNewTestSupport.expectedOpenCL("short",
+            "ReturnShortArrayNew", "returnShortArrayNew");
     private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test

--- a/src/test/java/com/aparapi/codegen/test/ReturnShortArrayNewTest.java
+++ b/src/test/java/com/aparapi/codegen/test/ReturnShortArrayNewTest.java
@@ -15,13 +15,34 @@
  */
 package com.aparapi.codegen.test;
 
-import com.aparapi.internal.exception.CodeGenException;
 import org.junit.Test;
 
 public class ReturnShortArrayNewTest extends com.aparapi.codegen.CodeGenJUnitBase {
 
-    private static final String[] expectedOpenCL = null;
-    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = CodeGenException.class;
+    private static final String[] expectedOpenCL = {
+        "typedef struct This_s{\n"
+            + "   int passid;\n"
+            + "}This;\n"
+            + "int get_pass_id(This *this){\n"
+            + "   return this->passid;\n"
+            + "}\n"
+            + " __global short* com_aparapi_codegen_test_ReturnShortArrayNew__returnShortArrayNew(This *this){\n"
+            + "   short returnArray3[1024];\n"
+            + "   return(returnArray3);\n"
+            + "}\n"
+            + "__kernel void run(\n"
+            + "   int passid\n"
+            + "){\n"
+            + "   This thisStruct;\n"
+            + "   This* this=&thisStruct;\n"
+            + "   this->passid = passid;\n"
+            + "   {\n"
+            + "      com_aparapi_codegen_test_ReturnShortArrayNew__returnShortArrayNew(this);\n"
+            + "      return;\n"
+            + "   }\n"
+            + "}"
+    };
+    private static final Class<? extends com.aparapi.internal.exception.AparapiException> expectedException = null;
 
     @Test
     public void ReturnShortArrayNewTest() {

--- a/src/test/java/com/aparapi/runtime/ReturnInstantiatedArrayDirectlyTest.java
+++ b/src/test/java/com/aparapi/runtime/ReturnInstantiatedArrayDirectlyTest.java
@@ -16,7 +16,6 @@
 package com.aparapi.runtime;
 
 import com.aparapi.Kernel;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -26,7 +25,6 @@ import static org.junit.Assert.assertArrayEquals;
 
 public class ReturnInstantiatedArrayDirectlyTest {
     @Test
-    @Ignore("Knon bug, ignoring until fixed.")
     public void test() {
         ReturnDoubleArrayNew kernel = new ReturnDoubleArrayNew();
         kernel.execute(1);


### PR DESCRIPTION
Fixes #66.

This changes code generation for `return new <primitive>[size]` so it emits the newly-created array as a local temporary and returns that temporary, matching the workaround pattern that already compiled.

What changed:
- handle `I_NEWARRAY` under `Return` without throwing `CodeGenException`
- add primitive `newarray` descriptor mapping for local array declarations
- update primitive direct-array-return codegen tests from expected exception to expected OpenCL
- unignore the existing runtime regression test

Validated locally with:
```
mvn -q -Djacoco.skip=true -Dtest='ReturnInstantiatedArrayDirectlyTest,Return*ArrayNewTest,Return*ArrayVarTest' test
```

Local note: the project POM contains `-XX:MaxPermSize=512m`, which JDK 17 rejects, so I removed that flag only for the local validation run and restored `pom.xml` afterward.
